### PR TITLE
ergonomics: more readible math code through Mul operator and Borrow trait

### DIFF
--- a/crates/sophus/src/examples/viewer_example.rs
+++ b/crates/sophus/src/examples/viewer_example.rs
@@ -37,7 +37,7 @@ pub fn make_distorted_frame() -> ImageFrame {
     let cy = 240.0;
 
     let unified_cam = DynCameraF64::new_unified(
-        &VecF64::from_array([focal_length, focal_length, cx, cy, 0.629, 1.22]),
+        VecF64::from_array([focal_length, focal_length, cx, cy, 0.629, 1.22]),
         image_size,
     );
 
@@ -47,7 +47,7 @@ pub fn make_distorted_frame() -> ImageFrame {
     for v in 0..image_size.height {
         for u in 0..image_size.width {
             let uv = VecF64::<2>::new(u as f64, v as f64);
-            let p_on_z1 = unified_cam.cam_unproj(&uv);
+            let p_on_z1 = unified_cam.cam_unproj(uv);
 
             if p_on_z1[0].abs() < 0.5 {
                 *img.mut_pixel(u, v) = SVec::<u8, 4>::new(255, 0, 0, 255);

--- a/crates/sophus_core/src/calculus/dual/dual_scalar.rs
+++ b/crates/sophus_core/src/calculus/dual/dual_scalar.rs
@@ -9,6 +9,7 @@ use crate::tensor::mut_tensor::InnerScalarToVec;
 use crate::tensor::mut_tensor::MutTensorDD;
 use approx::AbsDiffEq;
 use approx::RelativeEq;
+use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::ops::Add;
 use core::ops::AddAssign;
@@ -286,7 +287,7 @@ impl IsScalar<1> for DualScalar {
         [self.real_part]
     }
 
-    fn cos(self) -> DualScalar {
+    fn cos(&self) -> DualScalar {
         Self {
             real_part: self.real_part.cos(),
             dij_part: match self.dij_part.clone() {
@@ -301,7 +302,7 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn sin(self) -> DualScalar {
+    fn sin(&self) -> DualScalar {
         Self {
             real_part: self.real_part.sin(),
             dij_part: match self.dij_part.clone() {
@@ -316,7 +317,7 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn abs(self) -> Self {
+    fn abs(&self) -> Self {
         Self {
             real_part: self.real_part.abs(),
             dij_part: match self.dij_part.clone() {
@@ -332,7 +333,11 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn atan2(self, rhs: Self) -> Self {
+    fn atan2<S>(&self, rhs: S) -> Self
+    where
+        S: Borrow<Self>,
+    {
+        let rhs = rhs.borrow();
         let inv_sq_nrm: f64 =
             1.0 / (self.real_part * self.real_part + rhs.real_part * rhs.real_part);
         Self {
@@ -350,11 +355,11 @@ impl IsScalar<1> for DualScalar {
         self.real_part
     }
 
-    fn sqrt(self) -> Self {
+    fn sqrt(&self) -> Self {
         let sqrt = self.real_part.sqrt();
         Self {
             real_part: sqrt,
-            dij_part: match self.dij_part {
+            dij_part: match self.dij_part.clone() {
                 Some(dij) => {
                     let out_dij = <MutTensorDD<f64>>::from_map(&dij.view(), |dij: &f64| {
                         (*dij) * 1.0 / (2.0 * sqrt)
@@ -366,10 +371,10 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn to_vec(self) -> DualVector<1> {
+    fn to_vec(&self) -> DualVector<1> {
         DualVector::<1> {
             real_part: self.real_part.real_part().to_vec(),
-            dij_part: match self.dij_part {
+            dij_part: match self.dij_part.clone() {
                 Some(dij) => {
                     let tmp = dij.inner_scalar_to_vec();
                     Some(tmp)
@@ -379,7 +384,7 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn tan(self) -> Self {
+    fn tan(&self) -> Self {
         Self {
             real_part: self.real_part.tan(),
             dij_part: match self.dij_part.clone() {
@@ -396,7 +401,7 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn acos(self) -> Self {
+    fn acos(&self) -> Self {
         Self {
             real_part: self.real_part.acos(),
             dij_part: match self.dij_part.clone() {
@@ -411,7 +416,7 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn asin(self) -> Self {
+    fn asin(&self) -> Self {
         Self {
             real_part: self.real_part.asin(),
             dij_part: match self.dij_part.clone() {
@@ -426,7 +431,7 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn atan(self) -> Self {
+    fn atan(&self) -> Self {
         Self {
             real_part: self.real_part.atan(),
             dij_part: match self.dij_part.clone() {
@@ -441,7 +446,7 @@ impl IsScalar<1> for DualScalar {
         }
     }
 
-    fn fract(self) -> Self {
+    fn fract(&self) -> Self {
         Self {
             real_part: self.real_part.fract(),
             dij_part: match self.dij_part.clone() {
@@ -490,13 +495,13 @@ impl IsScalar<1> for DualScalar {
         self.real_part.less_equal(&rhs.real_part)
     }
 
-    fn to_dual(self) -> Self::DualScalar {
-        self
+    fn to_dual(&self) -> Self::DualScalar {
+        self.clone()
     }
 
-    fn select(self, mask: &Self::Mask, other: Self) -> Self {
+    fn select(&self, mask: &Self::Mask, other: Self) -> Self {
         if *mask {
-            self
+            self.clone()
         } else {
             other
         }

--- a/crates/sophus_core/src/linalg/batch_scalar.rs
+++ b/crates/sophus_core/src/linalg/batch_scalar.rs
@@ -14,6 +14,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use approx::AbsDiffEq;
 use approx::RelativeEq;
+use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::ops::AddAssign;
 use core::ops::Div;
@@ -233,7 +234,7 @@ where
         }
     }
 
-    fn abs(self) -> Self {
+    fn abs(&self) -> Self {
         BatchScalarF64 {
             0: SimdFloat::abs(self.0),
         }
@@ -249,57 +250,61 @@ where
         self.0.to_array()
     }
 
-    fn cos(self) -> Self {
+    fn cos(&self) -> Self {
         BatchScalarF64 {
             0: sleef::Sleef::cos(self.0),
         }
     }
 
-    fn sin(self) -> Self {
+    fn sin(&self) -> Self {
         BatchScalarF64 {
             0: sleef::Sleef::sin(self.0),
         }
     }
 
-    fn tan(self) -> Self {
+    fn tan(&self) -> Self {
         BatchScalarF64 {
             0: sleef::Sleef::tan(self.0),
         }
     }
 
-    fn acos(self) -> Self {
+    fn acos(&self) -> Self {
         BatchScalarF64 {
             0: sleef::Sleef::acos(self.0),
         }
     }
 
-    fn asin(self) -> Self {
+    fn asin(&self) -> Self {
         BatchScalarF64 {
             0: sleef::Sleef::asin(self.0),
         }
     }
 
-    fn atan(self) -> Self {
+    fn atan(&self) -> Self {
         BatchScalarF64 {
             0: sleef::Sleef::atan(self.0),
         }
     }
 
-    fn sqrt(self) -> Self {
+    fn sqrt(&self) -> Self {
         BatchScalarF64 { 0: self.0.sqrt() }
     }
 
-    fn atan2(self, x: Self) -> Self {
+    fn atan2<S>(&self, rhs: S) -> Self
+    where
+        S: Borrow<Self>,
+    {
+        let rhs = rhs.borrow();
         BatchScalarF64 {
-            0: sleef::Sleef::atan2(self.0, x.0),
+            0: sleef::Sleef::atan2(self.0, rhs.0),
         }
     }
 
-    fn to_vec(self) -> Self::Vector<1> {
+    fn to_vec(&self) -> Self::Vector<1> {
         BatchVecF64::<1, BATCH>::from_scalar(self)
     }
 
-    fn fract(self) -> Self {
+    fn fract(&self) -> Self {
         BatchScalarF64 {
             0: self.0.frfrexp(),
         }
@@ -317,11 +322,11 @@ where
 
     type DualMatrix<const ROWS: usize, const COLS: usize> = DualBatchMatrix<ROWS, COLS, BATCH>;
 
-    fn to_dual(self) -> Self::DualScalar {
-        DualBatchScalar::from_real_scalar(self)
+    fn to_dual(&self) -> Self::DualScalar {
+        DualBatchScalar::from_real_scalar(self.clone())
     }
 
-    fn select(self, mask: &Self::Mask, other: Self) -> Self {
+    fn select(&self, mask: &Self::Mask, other: Self) -> Self {
         BatchScalarF64 {
             0: mask.select(self.0, other.0),
         }

--- a/crates/sophus_core/src/linalg/scalar.rs
+++ b/crates/sophus_core/src/linalg/scalar.rs
@@ -8,6 +8,7 @@ use crate::prelude::*;
 use approx::assert_abs_diff_eq;
 use approx::AbsDiffEq;
 use approx::RelativeEq;
+use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::ops::Add;
 use core::ops::AddAssign;
@@ -123,22 +124,24 @@ pub trait IsScalar<const BATCH_SIZE: usize>:
     >;
 
     /// absolute value
-    fn abs(self) -> Self;
+    fn abs(&self) -> Self;
 
     /// arccosine
-    fn acos(self) -> Self;
+    fn acos(&self) -> Self;
 
     /// arcsine
-    fn asin(self) -> Self;
+    fn asin(&self) -> Self;
 
     /// arctangent
-    fn atan(self) -> Self;
+    fn atan(&self) -> Self;
 
     /// arctangent2
-    fn atan2(self, x: Self) -> Self;
+    fn atan2<S>(&self, x: S) -> Self
+    where
+        S: Borrow<Self>;
 
     /// cosine
-    fn cos(self) -> Self;
+    fn cos(&self) -> Self;
 
     /// eps
     fn eps() -> Self;
@@ -150,7 +153,7 @@ pub trait IsScalar<const BATCH_SIZE: usize>:
     fn floor(&self) -> Self::RealScalar;
 
     /// fractional part
-    fn fract(self) -> Self;
+    fn fract(&self) -> Self;
 
     /// Creates a scalar with all real lanes set the given value
     ///
@@ -189,7 +192,7 @@ pub trait IsScalar<const BATCH_SIZE: usize>:
     /// Return the self if the mask is true, otherwise the other value
     ///
     /// This is a lane-wise operation
-    fn select(self, mask: &Self::Mask, other: Self) -> Self;
+    fn select(&self, mask: &Self::Mask, other: Self) -> Self;
 
     /// Return the sign of the scalar
     ///
@@ -199,15 +202,15 @@ pub trait IsScalar<const BATCH_SIZE: usize>:
     fn signum(&self) -> Self;
 
     /// sine
-    fn sin(self) -> Self;
+    fn sin(&self) -> Self;
 
     /// square root
-    fn sqrt(self) -> Self;
+    fn sqrt(&self) -> Self;
 
     /// Returns dual number representation
     ///
     /// If self is a real number, the infinitesimal part is zero: (self, 0ϵ)
-    fn to_dual(self) -> Self::DualScalar;
+    fn to_dual(&self) -> Self::DualScalar;
 
     /// Return as a real array
     ///
@@ -215,10 +218,10 @@ pub trait IsScalar<const BATCH_SIZE: usize>:
     fn to_real_array(&self) -> [f64; BATCH_SIZE];
 
     /// tangent
-    fn tan(self) -> Self;
+    fn tan(&self) -> Self;
 
     /// return as a vector
-    fn to_vec(self) -> Self::Vector<1>;
+    fn to_vec(&self) -> Self::Vector<1>;
 
     /// zeros
     fn zeros() -> Self {
@@ -291,24 +294,24 @@ impl IsScalar<1> for f64 {
         alloc::vec![1.0, 2.0, 3.0]
     }
 
-    fn abs(self) -> f64 {
-        f64::abs(self)
+    fn abs(&self) -> f64 {
+        f64::abs(*self)
     }
 
-    fn cos(self) -> f64 {
-        f64::cos(self)
+    fn cos(&self) -> f64 {
+        f64::cos(*self)
     }
 
     fn eps() -> f64 {
         EPS_F64
     }
 
-    fn sin(self) -> f64 {
-        f64::sin(self)
+    fn sin(&self) -> f64 {
+        f64::sin(*self)
     }
 
-    fn sqrt(self) -> f64 {
-        f64::sqrt(self)
+    fn sqrt(&self) -> f64 {
+        f64::sqrt(*self)
     }
 
     fn from_f64(val: f64) -> f64 {
@@ -319,8 +322,11 @@ impl IsScalar<1> for f64 {
         val
     }
 
-    fn atan2(self, x: Self) -> Self {
-        self.atan2(x)
+    fn atan2<S>(&self, x: S) -> Self
+    where
+        S: Borrow<f64>,
+    {
+        f64::atan2(*self, *x.borrow())
     }
 
     fn from_real_array(arr: [Self::RealScalar; 1]) -> Self {
@@ -335,28 +341,28 @@ impl IsScalar<1> for f64 {
         *self
     }
 
-    fn to_vec(self) -> VecF64<1> {
-        VecF64::<1>::new(self)
+    fn to_vec(&self) -> VecF64<1> {
+        VecF64::<1>::new(*self)
     }
 
-    fn tan(self) -> Self {
-        self.tan()
+    fn tan(&self) -> Self {
+        f64::tan(*self)
     }
 
-    fn acos(self) -> Self {
-        self.acos()
+    fn acos(&self) -> Self {
+        f64::acos(*self)
     }
 
-    fn asin(self) -> Self {
-        self.asin()
+    fn asin(&self) -> Self {
+        f64::asin(*self)
     }
 
-    fn atan(self) -> Self {
-        self.atan()
+    fn atan(&self) -> Self {
+        f64::atan(*self)
     }
 
-    fn fract(self) -> Self {
-        f64::fract(self)
+    fn fract(&self) -> Self {
+        f64::fract(*self)
     }
 
     fn floor(&self) -> f64 {
@@ -375,13 +381,13 @@ impl IsScalar<1> for f64 {
 
     type DualMatrix<const ROWS: usize, const COLS: usize> = DualMatrix<ROWS, COLS>;
 
-    fn to_dual(self) -> Self::DualScalar {
-        DualScalar::from_f64(self)
+    fn to_dual(&self) -> Self::DualScalar {
+        DualScalar::from_f64(*self)
     }
 
-    fn select(self, mask: &Self::Mask, other: Self) -> Self {
+    fn select(&self, mask: &Self::Mask, other: Self) -> Self {
         if *mask {
-            self
+            *self
         } else {
             other
         }

--- a/crates/sophus_core/src/params.rs
+++ b/crates/sophus_core/src/params.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use crate::linalg::VecF64;
 use crate::points::example_points;
 use crate::prelude::*;
@@ -9,7 +11,9 @@ extern crate alloc;
 /// Parameter implementation.
 pub trait ParamsImpl<S: IsScalar<BATCH_SIZE>, const PARAMS: usize, const BATCH_SIZE: usize> {
     /// Is the parameter vector valid?
-    fn are_params_valid(params: &S::Vector<PARAMS>) -> S::Mask;
+    fn are_params_valid<P>(params: P) -> S::Mask
+    where
+        P: Borrow<S::Vector<PARAMS>>;
     /// Examples of valid parameter vectors.
     fn params_examples() -> alloc::vec::Vec<S::Vector<PARAMS>>;
     /// Examples of invalid parameter vectors.
@@ -21,15 +25,22 @@ pub trait HasParams<S: IsScalar<BATCH_SIZE>, const PARAMS: usize, const BATCH_SI
     ParamsImpl<S, PARAMS, BATCH_SIZE>
 {
     /// Create from parameters.
-    fn from_params(params: &S::Vector<PARAMS>) -> Self;
+    fn from_params<P>(params: P) -> Self
+    where
+        P: Borrow<S::Vector<PARAMS>>;
     /// Set parameters.
-    fn set_params(&mut self, params: &S::Vector<PARAMS>);
+    fn set_params<P>(&mut self, params: P)
+    where
+        P: Borrow<S::Vector<PARAMS>>;
     /// Get parameters.
     fn params(&self) -> &S::Vector<PARAMS>;
 }
 
 impl<const N: usize> ParamsImpl<f64, N, 1> for VecF64<N> {
-    fn are_params_valid(_params: &VecF64<N>) -> bool {
+    fn are_params_valid<P>(_params: P) -> bool
+    where
+        P: Borrow<VecF64<N>>,
+    {
         true
     }
 
@@ -43,12 +54,18 @@ impl<const N: usize> ParamsImpl<f64, N, 1> for VecF64<N> {
 }
 
 impl<const N: usize> HasParams<f64, N, 1> for VecF64<N> {
-    fn from_params(params: &VecF64<N>) -> Self {
-        *params
+    fn from_params<P>(params: P) -> Self
+    where
+        P: Borrow<VecF64<N>>,
+    {
+        *params.borrow()
     }
 
-    fn set_params(&mut self, params: &VecF64<N>) {
-        *self = *params
+    fn set_params<P>(&mut self, params: P)
+    where
+        P: Borrow<VecF64<N>>,
+    {
+        *self = *params.borrow();
     }
 
     fn params(&self) -> &VecF64<N> {

--- a/crates/sophus_lie/src/factor_lie_group.rs
+++ b/crates/sophus_lie/src/factor_lie_group.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use crate::lie_group::LieGroup;
 use crate::prelude::*;
 use crate::traits::IsRealLieFactorGroupImpl;
@@ -24,31 +26,44 @@ impl<
     > LieGroup<S, DOF, PARAMS, POINT, POINT, BATCH_SIZE, G>
 {
     /// V matrix - used in the exponential map
-    pub fn mat_v(tangent: &S::Vector<DOF>) -> S::Matrix<POINT, POINT> {
-        G::mat_v(tangent)
+    pub fn mat_v<T>(tangent: T) -> S::Matrix<POINT, POINT>
+    where
+        T: Borrow<S::Vector<DOF>>,
+    {
+        G::mat_v(tangent.borrow())
     }
 
     /// V matrix inverse - used in the logarithmic map
-    pub fn mat_v_inverse(tangent: &S::Vector<DOF>) -> S::Matrix<POINT, POINT> {
-        G::mat_v_inverse(tangent)
+    pub fn mat_v_inverse<T>(tangent: T) -> S::Matrix<POINT, POINT>
+    where
+        T: Borrow<S::Vector<DOF>>,
+    {
+        G::mat_v_inverse(tangent.borrow())
     }
 
     /// derivative of V matrix
-    pub fn dx_mat_v(tangent: &S::Vector<DOF>) -> [S::Matrix<POINT, POINT>; DOF] {
-        G::dx_mat_v(tangent)
+    pub fn dx_mat_v<T>(tangent: T) -> [S::Matrix<POINT, POINT>; DOF]
+    where
+        T: Borrow<S::Vector<DOF>>,
+    {
+        G::dx_mat_v(tangent.borrow())
     }
 
     /// derivative of V matrix inverse
-    pub fn dx_mat_v_inverse(tangent: &S::Vector<DOF>) -> [S::Matrix<POINT, POINT>; DOF] {
-        G::dx_mat_v_inverse(tangent)
+    pub fn dx_mat_v_inverse<T>(tangent: T) -> [S::Matrix<POINT, POINT>; DOF]
+    where
+        T: Borrow<S::Vector<DOF>>,
+    {
+        G::dx_mat_v_inverse(tangent.borrow())
     }
 
     /// derivative of V matrix times point
-    pub fn dparams_matrix_times_point(
-        params: &S::Vector<PARAMS>,
-        point: &S::Vector<POINT>,
-    ) -> S::Matrix<POINT, PARAMS> {
-        G::dparams_matrix_times_point(params, point)
+    pub fn dparams_matrix_times_point<PA, PO>(params: PA, point: PO) -> S::Matrix<POINT, PARAMS>
+    where
+        PA: Borrow<S::Vector<PARAMS>>,
+        PO: Borrow<S::Vector<POINT>>,
+    {
+        G::dparams_matrix_times_point(params.borrow(), point.borrow())
     }
 }
 

--- a/crates/sophus_lie/src/groups/isometry3.rs
+++ b/crates/sophus_lie/src/groups/isometry3.rs
@@ -1,9 +1,11 @@
+use core::borrow::Borrow;
+
 use log::warn;
 
 use super::rotation3::Rotation3Impl;
 use super::translation_product_product::TranslationProductGroupImpl;
-use crate::average::iterative_average;
-use crate::average::IterativeAverageError;
+use crate::lie_group::average::iterative_average;
+use crate::lie_group::average::IterativeAverageError;
 use crate::lie_group::LieGroup;
 use crate::prelude::*;
 use crate::traits::EmptySliceError;
@@ -21,55 +23,71 @@ pub type Isometry3F64 = Isometry3<f64, 1>;
 
 impl<S: IsScalar<BATCH>, const BATCH: usize> Isometry3<S, BATCH> {
     /// create isometry from translation and rotation
-    pub fn from_translation_and_rotation(
-        translation: &S::Vector<3>,
-        rotation: &Rotation3<S, BATCH>,
-    ) -> Self {
+    pub fn from_translation_and_rotation<P, F>(translation: P, rotation: F) -> Self
+    where
+        P: Borrow<S::Vector<3>>,
+        F: Borrow<Rotation3<S, BATCH>>,
+    {
         Self::from_translation_and_factor(translation, rotation)
     }
 
-    /// rotate around x axis
-    pub fn rot_x(theta: S) -> Self {
-        Self::from_rotation(&Rotation3::rot_x(theta))
-    }
-
-    /// rotate around y axis
-    pub fn rot_y(theta: S) -> Self {
-        Self::from_rotation(&Rotation3::rot_y(theta))
-    }
-
-    /// rotate around z axis
-    pub fn rot_z(theta: S) -> Self {
-        Self::from_rotation(&Rotation3::rot_z(theta))
-    }
-
-    /// translate along x axis
-    pub fn trans_x(x: S) -> Self {
-        Self::from_translation(&S::Vector::from_array([x, S::zero(), S::zero()]))
-    }
-
-    /// translate along y axis
-    pub fn trans_y(y: S) -> Self {
-        Self::from_translation(&S::Vector::from_array([S::zero(), y, S::zero()]))
-    }
-
-    /// translate along z axis
-    pub fn trans_z(z: S) -> Self {
-        Self::from_translation(&S::Vector::from_array([S::zero(), S::zero(), z]))
-    }
-
     /// create isometry from translation
-    pub fn from_translation(translation: &S::Vector<3>) -> Self {
-        Self::from_translation_and_factor(translation, &Rotation3::identity())
+    pub fn from_translation<P>(translation: P) -> Self
+    where
+        P: Borrow<S::Vector<3>>,
+    {
+        Self::from_translation_and_factor(translation, Rotation3::identity())
     }
 
     /// create isometry from rotation
-    pub fn from_rotation(rotation: &Rotation3<S, BATCH>) -> Self {
-        Self::from_translation_and_factor(&S::Vector::<3>::zeros(), rotation)
+    pub fn from_rotation<F>(rotation: F) -> Self
+    where
+        F: Borrow<Rotation3<S, BATCH>>,
+    {
+        Self::from_translation_and_factor(S::Vector::<3>::zeros(), rotation)
+    }
+
+    /// translate along x axis
+    pub fn trans_x<U>(x: U) -> Self
+    where
+        U: Borrow<S>,
+    {
+        let x: &S = x.borrow();
+        Self::from_translation(S::Vector::from_array([x.clone(), S::zero(), S::zero()]))
+    }
+
+    /// translate along y axis
+    pub fn trans_y<U>(y: U) -> Self
+    where
+        U: Borrow<S>,
+    {
+        let y: &S = y.borrow();
+        Self::from_translation(S::Vector::from_array([S::zero(), y.clone(), S::zero()]))
+    }
+
+    /// translate along z axis
+    pub fn trans_z<U>(z: U) -> Self
+    where
+        U: Borrow<S>,
+    {
+        let z: &S = z.borrow();
+        Self::from_translation(S::Vector::from_array([S::zero(), S::zero(), z.clone()]))
+    }
+
+    /// Rotate by angle
+    pub fn rot_x<U>(theta: U) -> Self
+    where
+        U: Borrow<S>,
+    {
+        let theta: &S = theta.borrow();
+        Self::from_rotation(Rotation3::rot_x(theta))
     }
 
     /// set rotation
-    pub fn set_rotation(&mut self, rotation: &Rotation3<S, BATCH>) {
+    pub fn set_rotation<F>(&mut self, rotation: F)
+    where
+        F: Borrow<Rotation3<S, BATCH>>,
+    {
         self.set_factor(rotation)
     }
 
@@ -110,7 +128,7 @@ impl<S: IsSingleScalar + PartialOrd> HasAverage<S, 6, 7, 3, 4> for Isometry3<S, 
 
 #[test]
 fn isometry3_prop_tests() {
-    use crate::real_lie_group::RealLieGroupTest;
+    use crate::lie_group::real_lie_group::RealLieGroupTest;
     use sophus_core::calculus::dual::dual_scalar::DualScalar;
 
     #[cfg(feature = "simd")]

--- a/crates/sophus_lie/src/groups/rotation3.rs
+++ b/crates/sophus_lie/src/groups/rotation3.rs
@@ -1,5 +1,5 @@
-use crate::average::iterative_average;
-use crate::average::IterativeAverageError;
+use crate::lie_group::average::iterative_average;
+use crate::lie_group::average::IterativeAverageError;
 use crate::lie_group::LieGroup;
 use crate::prelude::*;
 use crate::traits::EmptySliceError;
@@ -8,6 +8,7 @@ use crate::traits::HasDisambiguate;
 use crate::traits::IsLieGroupImpl;
 use crate::traits::IsRealLieFactorGroupImpl;
 use crate::traits::IsRealLieGroupImpl;
+use core::borrow::Borrow;
 use core::f64;
 use core::marker::PhantomData;
 use log::warn;
@@ -42,96 +43,96 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> ParamsImpl<S, 4, BATCH> for Rotatio
         const NEAR_MINUS_PI: f64 = f64::consts::PI - 1e-6;
 
         alloc::vec![
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, 0.0, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, 0.0, 0.0]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.1, 0.5, -0.1]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.1, 0.5, -0.1]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.1, 2.0, -0.1]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.1, 2.0, -0.1]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, 0.2, 1.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, 0.2, 1.0]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([-0.2, 0.0, 0.8]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([-0.2, 0.0, 0.8]))
                 .params()
                 .clone(),
             // Test cases around +π and -π
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([NEAR_PI, 0.0, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([NEAR_PI, 0.0, 0.0]))
                 .params()
                 .clone(), // +π rotation about the x-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([NEAR_MINUS_PI, 0.0, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([NEAR_MINUS_PI, 0.0, 0.0]))
                 .params()
                 .clone(), // -π rotation about the x-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, NEAR_PI, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, NEAR_PI, 0.0]))
                 .params()
                 .clone(), // +π rotation about the y-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, NEAR_MINUS_PI, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, NEAR_MINUS_PI, 0.0]))
                 .params()
                 .clone(), // -π rotation about the y-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, 0.0, NEAR_PI]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, 0.0, NEAR_PI]))
                 .params()
                 .clone(), // +π rotation about the z-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, 0.0, NEAR_MINUS_PI]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, 0.0, NEAR_MINUS_PI]))
                 .params()
                 .clone(), // -π rotation about the z-axis
             // Close to +π and -π, but not exactly, to test boundary behavior
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([3.0, 0.0, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([3.0, 0.0, 0.0]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([-3.0, 0.0, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([-3.0, 0.0, 0.0]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, 3.0, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, 3.0, 0.0]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, -3.0, 0.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, -3.0, 0.0]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, 0.0, 3.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, 0.0, 3.0]))
                 .params()
                 .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([0.0, 0.0, -3.0]))
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([0.0, 0.0, -3.0]))
                 .params()
                 .clone(),
             // Halfway to π rotations, to cover intermediate rotations
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 f64::consts::FRAC_PI_2,
                 0.0,
                 0.0,
             ]))
             .params()
             .clone(), // +π/2 about x-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 0.0,
                 f64::consts::FRAC_PI_2,
                 0.0,
             ]))
             .params()
             .clone(), // +π/2 about y-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 0.0,
                 0.0,
                 f64::consts::FRAC_PI_2,
             ]))
             .params()
             .clone(), // +π/2 about z-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 -f64::consts::FRAC_PI_2,
                 0.0,
                 0.0,
             ]))
             .params()
             .clone(), // -π/2 about x-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 0.0,
                 -f64::consts::FRAC_PI_2,
                 0.0,
             ]))
             .params()
             .clone(), // -π/2 about y-axis
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 0.0,
                 0.0,
                 -f64::consts::FRAC_PI_2,
@@ -139,21 +140,21 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> ParamsImpl<S, 4, BATCH> for Rotatio
             .params()
             .clone(), // -π/2 about z-axis
             // Complex combination rotations around the boundary
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 NEAR_PI / 2.0,
                 NEAR_PI / 2.0,
                 0.0,
             ]))
             .params()
             .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 NEAR_MINUS_PI / 2.0,
                 0.0,
                 NEAR_PI / 2.0,
             ]))
             .params()
             .clone(),
-            Rotation3::<S, BATCH>::exp(&S::Vector::<3>::from_f64_array([
+            Rotation3::<S, BATCH>::exp(S::Vector::<3>::from_f64_array([
                 0.0,
                 NEAR_PI / 2.0,
                 NEAR_PI / 2.0,
@@ -171,8 +172,11 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> ParamsImpl<S, 4, BATCH> for Rotatio
         ]
     }
 
-    fn are_params_valid(params: &S::Vector<4>) -> S::Mask {
-        let norm = params.norm();
+    fn are_params_valid<P>(params: P) -> S::Mask
+    where
+        P: Borrow<S::Vector<4>>,
+    {
+        let norm = params.borrow().norm();
         (norm - S::from_f64(1.0))
             .abs()
             .less_equal(&S::from_f64(EPS_F64))
@@ -255,7 +259,7 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsLieGroupImpl<S, 3, 4, 3, 3, BATCH
         let n = squared_n.sqrt();
 
         let sign = S::from_f64(-1.0).select(&w.less_equal(&S::from_f64(0.0)), S::from_f64(1.0));
-        let atan_nbyw = sign.clone() * n.clone().atan2(sign * w);
+        let atan_nbyw = sign.clone() * n.atan2(sign * w);
 
         let t = S::from_f64(2.0) * atan_nbyw / n;
 
@@ -307,26 +311,21 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsLieGroupImpl<S, 3, 4, 3, 3, BATCH
 
     fn matrix(params: &S::Vector<4>) -> S::Matrix<3, 3> {
         let ivec = params.get_fixed_subvec::<3>(1);
-        let re = params.get_elem(0);
+        let re = &params.get_elem(0);
 
         let unit_x = S::Vector::from_f64_array([1.0, 0.0, 0.0]);
         let unit_y = S::Vector::from_f64_array([0.0, 1.0, 0.0]);
         let unit_z = S::Vector::from_f64_array([0.0, 0.0, 1.0]);
 
-        let two = S::from_f64(2.0);
+        let two = &S::from_f64(2.0);
 
-        let uv_x: S::Vector<3> =
-            cross::<S, BATCH>(ivec.clone(), unit_x.clone()).scaled(two.clone());
-        let uv_y: S::Vector<3> =
-            cross::<S, BATCH>(ivec.clone(), unit_y.clone()).scaled(two.clone());
-        let uv_z: S::Vector<3> = cross::<S, BATCH>(ivec.clone(), unit_z.clone()).scaled(two);
+        let uv_x: S::Vector<3> = cross::<S, BATCH>(&ivec, &unit_x).scaled(two);
+        let uv_y: S::Vector<3> = cross::<S, BATCH>(&ivec, &unit_y).scaled(two);
+        let uv_z: S::Vector<3> = cross::<S, BATCH>(&ivec, &unit_z).scaled(two);
 
-        let col_x =
-            unit_x + cross::<S, BATCH>(ivec.clone(), uv_x.clone()) + uv_x.scaled(re.clone());
-        let col_y =
-            unit_y + cross::<S, BATCH>(ivec.clone(), uv_y.clone()) + uv_y.scaled(re.clone());
-        let col_z =
-            unit_z + cross::<S, BATCH>(ivec.clone(), uv_z.clone()) + uv_z.scaled(re.clone());
+        let col_x = unit_x + cross::<S, BATCH>(&ivec, &uv_x) + uv_x.scaled(re);
+        let col_y = unit_y + cross::<S, BATCH>(&ivec, &uv_y) + uv_y.scaled(re);
+        let col_z = unit_z + cross::<S, BATCH>(&ivec, &uv_z) + uv_z.scaled(re);
 
         S::Matrix::block_mat1x2::<1, 2>(
             col_x.to_mat(),
@@ -349,10 +348,10 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsLieGroupImpl<S, 3, 4, 3, 3, BATCH
         let lhs_ivec = lhs_params.get_fixed_subvec::<3>(1);
         let rhs_ivec = rhs_params.get_fixed_subvec::<3>(1);
 
-        let re = lhs_re.clone() * rhs_re.clone() - lhs_ivec.clone().dot(rhs_ivec.clone());
+        let re = lhs_re.clone() * rhs_re.clone() - lhs_ivec.dot(&rhs_ivec);
         let ivec = rhs_ivec.scaled(lhs_re)
             + lhs_ivec.scaled(rhs_re)
-            + cross::<S, BATCH>(lhs_ivec, rhs_ivec);
+            + cross::<S, BATCH>(&lhs_ivec, &rhs_ivec);
 
         let mut params = S::Vector::block_vec2(re.to_vec(), ivec);
 
@@ -387,7 +386,7 @@ impl<S: IsRealScalar<BATCH>, const BATCH: usize> IsRealLieGroupImpl<S, 3, 4, 3, 
         let lhs_ivec = a.get_fixed_subvec::<3>(1);
         let rhs_ivec = b.get_fixed_subvec::<3>(1);
 
-        let re = lhs_re * rhs_re - lhs_ivec.clone().dot(rhs_ivec.clone());
+        let re = lhs_re * rhs_re - lhs_ivec.dot(rhs_ivec);
 
         let is_positive = S::from_f64(0.0).less_equal(&re);
 
@@ -418,7 +417,7 @@ impl<S: IsRealScalar<BATCH>, const BATCH: usize> IsRealLieGroupImpl<S, 3, 4, 3, 
         let rhs_re = b.get_elem(0);
         let lhs_ivec = a.get_fixed_subvec::<3>(1);
         let rhs_ivec = b.get_fixed_subvec::<3>(1);
-        let re = lhs_re * rhs_re - lhs_ivec.clone().dot(rhs_ivec.clone());
+        let re = lhs_re * rhs_re - lhs_ivec.dot(&rhs_ivec);
         let is_positive = S::from_f64(0.0).less_equal(&re);
 
         let a_real = a.get_elem(0);
@@ -443,8 +442,8 @@ impl<S: IsRealScalar<BATCH>, const BATCH: usize> IsRealLieGroupImpl<S, 3, 4, 3, 
         )
     }
 
-    fn dx_exp_x_times_point_at_0(point: S::Vector<3>) -> S::Matrix<3, 3> {
-        Self::hat(&-point)
+    fn dx_exp_x_times_point_at_0(point: &S::Vector<3>) -> S::Matrix<3, 3> {
+        Self::hat(&-point.clone())
     }
 
     fn dx_exp(omega: &S::Vector<3>) -> S::Matrix<4, 3> {
@@ -503,7 +502,7 @@ impl<S: IsRealScalar<BATCH>, const BATCH: usize> IsRealLieGroupImpl<S, 3, 4, 3, 
         let factor =
             S::from_f64(2.0) * w / (squared_n * (squared_n + w * w)) - theta / (squared_n * n);
 
-        let mm = ivec.clone().outer(ivec).scaled(factor);
+        let mm = ivec.outer(&ivec).scaled(factor);
 
         m0.select(
             &near_zero,
@@ -532,13 +531,13 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> crate::traits::IsLieFactorGroupImpl
     fn mat_v(omega: &S::Vector<3>) -> S::Matrix<3, 3> {
         let theta_sq = omega.squared_norm();
         let mat_omega: S::Matrix<3, 3> = Rotation3Impl::<S, BATCH>::hat(omega);
-        let mat_omega_sq = mat_omega.clone().mat_mul(mat_omega.clone());
+        let mat_omega_sq = mat_omega.mat_mul(&mat_omega);
 
         let near_zero = theta_sq.less_equal(&S::from_f64(EPS_F64));
 
         let mat_v0 = S::Matrix::<3, 3>::identity() + mat_omega.scaled(S::from_f64(0.5));
 
-        let theta = theta_sq.clone().sqrt();
+        let theta = theta_sq.sqrt();
         let mat_v = S::Matrix::<3, 3>::identity()
             + mat_omega.scaled((S::from_f64(1.0) - theta.clone().cos()) / theta_sq.clone())
             + mat_omega_sq.scaled((theta.clone() - theta.clone().sin()) / (theta_sq * theta));
@@ -547,16 +546,16 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> crate::traits::IsLieFactorGroupImpl
     }
 
     fn mat_v_inverse(omega: &S::Vector<3>) -> S::Matrix<3, 3> {
-        let theta_sq = omega.clone().dot(omega.clone());
+        let theta_sq = omega.dot(omega);
         let mat_omega: S::Matrix<3, 3> = Rotation3Impl::<S, BATCH>::hat(omega);
-        let mat_omega_sq = mat_omega.clone().mat_mul(mat_omega.clone());
+        let mat_omega_sq = mat_omega.mat_mul(&mat_omega);
 
         let near_zero = theta_sq.less_equal(&S::from_f64(EPS_F64));
 
         let mat_v_inv0 = S::Matrix::<3, 3>::identity() - mat_omega.scaled(S::from_f64(0.5))
             + mat_omega_sq.scaled(S::from_f64(1. / 12.));
 
-        let theta = theta_sq.clone().sqrt();
+        let theta = theta_sq.sqrt();
         let half_theta = S::from_f64(0.5) * theta.clone();
 
         let mat_v_inv = S::Matrix::<3, 3>::identity() - mat_omega.scaled(S::from_f64(0.5))
@@ -591,7 +590,7 @@ impl<S: IsRealScalar<BATCH>, const BATCH: usize> IsRealLieFactorGroupImpl<S, 3, 
         let near_zero = theta_sq.less_equal(&S::from_f64(EPS_F64));
 
         let mat_omega: S::Matrix<3, 3> = Rotation3Impl::<S, BATCH>::hat(omega);
-        let mat_omega_sq = mat_omega.clone().mat_mul(mat_omega.clone());
+        let mat_omega_sq = mat_omega.mat_mul(&mat_omega);
 
         let omega_x = omega.get_elem(0);
         let omega_y = omega.get_elem(1);
@@ -693,7 +692,7 @@ impl<S: IsRealScalar<BATCH>, const BATCH: usize> IsRealLieFactorGroupImpl<S, 3, 
         let theta = theta_sq.sqrt();
         let half_theta = S::from_f64(0.5) * theta;
         let mat_omega: S::Matrix<3, 3> = Rotation3Impl::<S, BATCH>::hat(omega);
-        let mat_omega_sq = mat_omega.clone().mat_mul(mat_omega);
+        let mat_omega_sq = mat_omega.mat_mul(&mat_omega);
 
         let dt_mat_omega_pos_idx = [[2, 1], [0, 2], [1, 0]];
         let dt_mat_omega_neg_idx = [[1, 2], [2, 0], [0, 1]];
@@ -763,18 +762,42 @@ pub type Rotation3F64 = Rotation3<f64, 1>;
 
 impl<S: IsScalar<BATCH>, const BATCH: usize> Rotation3<S, BATCH> {
     /// Rotation around the x-axis.
-    pub fn rot_x(theta: S) -> Self {
-        Rotation3::exp(&S::Vector::<3>::from_array([theta, S::zero(), S::zero()]))
+    pub fn rot_x<U>(theta: U) -> Self
+    where
+        U: Borrow<S>,
+    {
+        let theta: &S = theta.borrow();
+        Rotation3::exp(S::Vector::<3>::from_array([
+            theta.clone(),
+            S::zero(),
+            S::zero(),
+        ]))
     }
 
     /// Rotation around the y-axis.
-    pub fn rot_y(theta: S) -> Self {
-        Rotation3::exp(&S::Vector::<3>::from_array([S::zero(), theta, S::zero()]))
+    pub fn rot_y<U>(theta: U) -> Self
+    where
+        U: Borrow<S>,
+    {
+        let theta: &S = theta.borrow();
+        Rotation3::exp(S::Vector::<3>::from_array([
+            S::zero(),
+            theta.clone(),
+            S::zero(),
+        ]))
     }
 
     /// Rotation around the z-axis.
-    pub fn rot_z(theta: S) -> Self {
-        Rotation3::exp(&S::Vector::<3>::from_array([S::zero(), S::zero(), theta]))
+    pub fn rot_z<U>(theta: U) -> Self
+    where
+        U: Borrow<S>,
+    {
+        let theta: &S = theta.borrow();
+        Rotation3::exp(S::Vector::<3>::from_array([
+            S::zero(),
+            S::zero(),
+            theta.clone(),
+        ]))
     }
 }
 
@@ -790,7 +813,11 @@ impl<S: IsSingleScalar + PartialOrd> Rotation3<S, 1> {
 
     /// From a 3x3 rotation matrix. The matrix must be a valid rotation matrix,
     /// i.e., it must be orthogonal with determinant 1, otherwise None is returned.
-    pub fn try_from_mat(mat_r: &S::SingleMatrix<3, 3>) -> Option<Rotation3<S, 1>> {
+    pub fn try_from_mat<M>(mat_r: M) -> Option<Rotation3<S, 1>>
+    where
+        M: Borrow<S::SingleMatrix<3, 3>>,
+    {
+        let mat_r = mat_r.borrow();
         if !Self::is_orthogonal_with_positive_det(&mat_r.single_real_matrix(), EPS_F64) {
             return None;
         }
@@ -924,7 +951,7 @@ impl<S: IsSingleScalar + PartialOrd> Rotation3<S, 1> {
 #[test]
 fn rotation3_prop_tests() {
     use crate::factor_lie_group::RealFactorLieGroupTest;
-    use crate::real_lie_group::RealLieGroupTest;
+    use crate::lie_group::real_lie_group::RealLieGroupTest;
     use sophus_core::calculus::dual::dual_scalar::DualScalar;
     #[cfg(feature = "simd")]
     use sophus_core::calculus::dual::DualBatchScalar;
@@ -979,7 +1006,7 @@ fn from_matrix_test() {
         let mat: MatF64<3, 3> = q.matrix();
 
         info!("mat = {:?}", mat);
-        let q2: Rotation3<f64, 1> = Rotation3::try_from_mat(&mat).unwrap();
+        let q2: Rotation3<f64, 1> = Rotation3::try_from_mat(mat).unwrap();
         let mat2 = q2.matrix();
 
         info!("mat2 = {:?}", mat2);
@@ -988,9 +1015,9 @@ fn from_matrix_test() {
 
     // Iterate over all tangent too, just to get more examples.
     for t in Rotation3::<f64, 1>::tangent_examples() {
-        let mat: MatF64<3, 3> = Rotation3::<f64, 1>::exp(&t).matrix();
+        let mat: MatF64<3, 3> = Rotation3::<f64, 1>::exp(t).matrix();
         info!("mat = {:?}", mat);
-        let t2: Rotation3<f64, 1> = Rotation3::try_from_mat(&mat).unwrap();
+        let t2: Rotation3<f64, 1> = Rotation3::try_from_mat(mat).unwrap();
         let mat2 = t2.matrix();
         info!("mat2 = {:?}", mat2);
         assert_relative_eq!(mat, mat2, epsilon = EPS_F64);

--- a/crates/sophus_lie/src/lib.rs
+++ b/crates/sophus_lie/src/lib.rs
@@ -22,17 +22,8 @@ pub use crate::lie_group::LieGroup;
 /// Lie groups
 pub mod factor_lie_group;
 
-/// Lie group as a manifold
-pub mod lie_group_manifold;
-
 /// Lie group traits
 pub mod traits;
-
-/// Real lie group
-pub mod real_lie_group;
-
-/// Lie group average
-pub mod average;
 
 /// sophus_lie prelude
 pub mod prelude {

--- a/crates/sophus_lie/src/lie_group/average.rs
+++ b/crates/sophus_lie/src/lie_group/average.rs
@@ -53,18 +53,13 @@ pub fn iterative_average<
 
         for parent_from_body in parent_from_body_transforms {
             average_tangent = average_tangent
-                + parent_from_body_average
-                    .inverse()
-                    .group_mul(parent_from_body)
+                + (parent_from_body_average.inverse() * parent_from_body)
                     .log()
                     .scaled(w.clone());
         }
         let refined_parent_from_body_average =
-            parent_from_body_average.group_mul(&LieGroup::exp(&average_tangent));
-        let step = refined_parent_from_body_average
-            .inverse()
-            .group_mul(&parent_from_body_average)
-            .log();
+            parent_from_body_average.clone() * LieGroup::exp(&average_tangent);
+        let step = (refined_parent_from_body_average.inverse() * parent_from_body_average).log();
         if step.squared_norm() < S::from_f64(EPS_F64) {
             return Ok(refined_parent_from_body_average);
         }
@@ -109,11 +104,7 @@ macro_rules! def_average_test_template {
                     for parent_from_b in Self::element_examples() {
                         // test: average of two elements is identical to interpolation
 
-                        if parent_from_a
-                            .inverse()
-                            .group_mul(&parent_from_b)
-                            .has_shortest_path_ambiguity()
-                        {
+                        if (parent_from_a.inverse() * parent_from_b).has_shortest_path_ambiguity() {
                             continue;
                         }
                         let averaged_element =
@@ -135,9 +126,7 @@ macro_rules! def_average_test_template {
 
                             let w = 1.0 / (list.len() as f64);
                             for parent_from_x in list {
-                                average_tangent += parent_from_average
-                                    .inverse()
-                                    .group_mul(&parent_from_x)
+                                average_tangent += (parent_from_average.inverse() * parent_from_x)
                                     .log()
                                     .scaled(w);
                             }

--- a/crates/sophus_lie/src/lie_group/group_mul.rs
+++ b/crates/sophus_lie/src/lie_group/group_mul.rs
@@ -1,0 +1,80 @@
+use crate::lie_group::LieGroup;
+use crate::traits::IsLieGroupImpl;
+use core::ops::Mul;
+use sophus_core::prelude::IsScalar;
+
+// a * b
+impl<
+        S: IsScalar<BATCH_SIZE>,
+        const DOF: usize,
+        const PARAMS: usize,
+        const POINT: usize,
+        const AMBIENT: usize,
+        const BATCH_SIZE: usize,
+        G: IsLieGroupImpl<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE>,
+    > Mul<LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>>
+    for LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>
+{
+    type Output = LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        self.group_mul(&rhs)
+    }
+}
+
+// a * &b
+impl<
+        S: IsScalar<BATCH_SIZE>,
+        const DOF: usize,
+        const PARAMS: usize,
+        const POINT: usize,
+        const AMBIENT: usize,
+        const BATCH_SIZE: usize,
+        G: IsLieGroupImpl<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE>,
+    > Mul<&LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>>
+    for LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>
+{
+    type Output = LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>;
+
+    fn mul(self, rhs: &Self) -> Self::Output {
+        self.group_mul(rhs)
+    }
+}
+
+// &a * &b
+impl<
+        S: IsScalar<BATCH_SIZE>,
+        const DOF: usize,
+        const PARAMS: usize,
+        const POINT: usize,
+        const AMBIENT: usize,
+        const BATCH_SIZE: usize,
+        G: IsLieGroupImpl<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE>,
+    > Mul<LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>>
+    for &LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>
+{
+    type Output = LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>;
+
+    fn mul(self, rhs: LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>) -> Self::Output {
+        self.group_mul(&rhs)
+    }
+}
+
+// a * &b
+impl<
+        S: IsScalar<BATCH_SIZE>,
+        const DOF: usize,
+        const PARAMS: usize,
+        const POINT: usize,
+        const AMBIENT: usize,
+        const BATCH_SIZE: usize,
+        G: IsLieGroupImpl<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE>,
+    > Mul<&LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>>
+    for &LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>
+{
+    type Output = LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>;
+
+    fn mul(self, rhs: &LieGroup<S, DOF, PARAMS, POINT, AMBIENT, BATCH_SIZE, G>) -> Self::Output {
+        self.group_mul(rhs)
+    }
+}

--- a/crates/sophus_lie/src/traits.rs
+++ b/crates/sophus_lie/src/traits.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use core::borrow::Borrow;
 use core::fmt::Debug;
 use sophus_core::manifold::traits::TangentImpl;
 use sophus_core::params::ParamsImpl;
@@ -141,7 +142,7 @@ pub trait IsRealLieGroupImpl<
     fn dx_log_x(params: &S::Vector<PARAMS>) -> S::Matrix<DOF, PARAMS>;
 
     /// derivative of exponential map times a point at the identity
-    fn dx_exp_x_times_point_at_0(point: S::Vector<POINT>) -> S::Matrix<POINT, DOF>;
+    fn dx_exp_x_times_point_at_0(point: &S::Vector<POINT>) -> S::Matrix<POINT, DOF>;
 
     /// are there multiple shortest paths to the identity?
     fn has_shortest_path_ambiguity(params: &S::Vector<PARAMS>) -> S::Mask;
@@ -272,15 +273,22 @@ pub trait IsTranslationProductGroup<
     type Impl;
 
     /// Create from translation and factor group element
-    fn from_translation_and_factor(translation: &S::Vector<POINT>, factor: &FactorGroup) -> Self;
+    fn from_translation_and_factor<P, F>(translation: P, factor: F) -> Self
+    where
+        P: Borrow<S::Vector<POINT>>,
+        F: Borrow<FactorGroup>;
 
     /// set translation
-    fn set_translation(&mut self, translation: &S::Vector<POINT>);
+    fn set_translation<P>(&mut self, translation: P)
+    where
+        P: Borrow<S::Vector<POINT>>;
     /// get translation
     fn translation(&self) -> S::Vector<POINT>;
 
     /// set factor group element
-    fn set_factor(&mut self, factor: &FactorGroup);
+    fn set_factor<F>(&mut self, factor: F)
+    where
+        F: Borrow<FactorGroup>;
 
     /// get factor group element
     fn factor(&self) -> FactorGroup;

--- a/crates/sophus_opt/src/example_problems/cam_calib.rs
+++ b/crates/sophus_opt/src/example_problems/cam_calib.rs
@@ -47,12 +47,12 @@ impl CamCalibProblem {
         let true_world_from_cameras = alloc::vec![
             Isometry3::identity(),
             Isometry3::from_translation_and_factor(
-                &VecF64::<3>::new(0.0, 1.0, 0.0),
-                &Rotation3::identity(),
+                VecF64::<3>::new(0.0, 1.0, 0.0),
+                Rotation3::identity(),
             ),
             Isometry3::from_translation_and_factor(
-                &VecF64::<3>::new(0.0, 2.0, 0.0),
-                &Rotation3::identity(),
+                VecF64::<3>::new(0.0, 2.0, 0.0),
+                Rotation3::identity(),
             ),
         ];
         use rand::prelude::*;
@@ -64,7 +64,7 @@ impl CamCalibProblem {
         };
 
         let true_intrinsics = PinholeCamera::<f64, 1>::from_params_and_size(
-            &VecF64::<4>::new(600.0, 600.0, 320.0, 240.0),
+            VecF64::<4>::new(600.0, 600.0, 320.0, 240.0),
             image_size,
         );
 
@@ -81,16 +81,15 @@ impl CamCalibProblem {
                 entity_indices: [0, 0, i],
             });
 
-            let true_point_in_cam0 = true_intrinsics.cam_unproj_with_z(&true_uv_in_img0, 10.0);
-            true_points_in_world.push(true_world_from_cameras[0].transform(&true_point_in_cam0));
-            let true_uv_in_img0_proof = true_intrinsics.cam_proj(&true_point_in_cam0);
+            let true_point_in_cam0 = true_intrinsics.cam_unproj_with_z(true_uv_in_img0, 10.0);
+            true_points_in_world.push(true_world_from_cameras[0].transform(true_point_in_cam0));
+            let true_uv_in_img0_proof = true_intrinsics.cam_proj(true_point_in_cam0);
             approx::assert_abs_diff_eq!(true_uv_in_img0, true_uv_in_img0_proof, epsilon = 0.1);
 
-            let true_cam1_from_cam0 = true_world_from_cameras[1]
-                .inverse()
-                .group_mul(&true_world_from_cameras[0]);
-            let true_point_in_cam1 = true_cam1_from_cam0.transform(&true_point_in_cam0);
-            let true_uv_in_img1 = true_intrinsics.cam_proj(&true_point_in_cam1);
+            let true_cam1_from_cam0 =
+                true_world_from_cameras[1].inverse() * true_world_from_cameras[0];
+            let true_point_in_cam1 = true_cam1_from_cam0.transform(true_point_in_cam0);
+            let true_uv_in_img1 = true_intrinsics.cam_proj(true_point_in_cam1);
             let img_noise = VecF64::<2>::new(rng.gen::<f64>() - 0.5, rng.gen::<f64>() - 0.5);
 
             if spurious_matches && i == 0 {
@@ -107,11 +106,10 @@ impl CamCalibProblem {
                 });
             }
 
-            let true_cam2_from_cam0 = true_world_from_cameras[2]
-                .inverse()
-                .group_mul(&true_world_from_cameras[0]);
-            let true_point_in_cam2 = true_cam2_from_cam0.transform(&true_point_in_cam0);
-            let true_uv_in_img2 = true_intrinsics.cam_proj(&true_point_in_cam2);
+            let true_cam2_from_cam0 =
+                true_world_from_cameras[2].inverse() * true_world_from_cameras[0];
+            let true_point_in_cam2 = true_cam2_from_cam0.transform(true_point_in_cam0);
+            let true_uv_in_img2 = true_intrinsics.cam_proj(true_point_in_cam2);
             let img_noise = VecF64::<2>::new(rng.gen::<f64>() - 0.5, rng.gen::<f64>() - 0.5);
             observations.push(ReprojTermSignature {
                 uv_in_image: true_uv_in_img2 + img_noise,

--- a/crates/sophus_opt/src/example_problems/cost_fn/isometry2_prior.rs
+++ b/crates/sophus_opt/src/example_problems/cost_fn/isometry2_prior.rs
@@ -43,7 +43,7 @@ fn res_fn<Scalar: IsSingleScalar + IsScalar<1>>(
     isometry: Isometry2<Scalar, 1>,
     isometry_prior_mean: Isometry2<Scalar, 1>,
 ) -> Scalar::Vector<3> {
-    Isometry2::<Scalar, 1>::group_mul(&isometry, &isometry_prior_mean.inverse()).log()
+    (isometry * isometry_prior_mean.inverse()).log()
 }
 
 impl IsResidualFn<3, 1, (), Isometry2F64, Isometry2F64> for Isometry2PriorCostFn {
@@ -60,12 +60,10 @@ impl IsResidualFn<3, 1, (), Isometry2F64, Isometry2F64> for Isometry2PriorCostFn
 
         let residual = res_fn(isometry, *isometry_prior_mean);
         let dx_res_fn = |x: DualVector<3>| -> DualVector<3> {
-            let pp = Isometry2::<DualScalar, 1>::exp(&x).group_mul(&isometry.to_dual_c());
+            let pp = Isometry2::<DualScalar, 1>::exp(&x) * isometry.to_dual_c();
             res_fn(
                 pp,
-                Isometry2::from_params(&DualVector::from_real_vector(
-                    *isometry_prior_mean.params(),
-                )),
+                Isometry2::from_params(DualVector::from_real_vector(*isometry_prior_mean.params())),
             )
         };
 

--- a/crates/sophus_opt/src/example_problems/cost_fn/isometry3_prior.rs
+++ b/crates/sophus_opt/src/example_problems/cost_fn/isometry3_prior.rs
@@ -44,7 +44,7 @@ fn res_fn<Scalar: IsScalar<1> + IsSingleScalar>(
     isometry: Isometry3<Scalar, 1>,
     isometry_prior_mean: Isometry3<Scalar, 1>,
 ) -> Scalar::Vector<6> {
-    Isometry3::<Scalar, 1>::group_mul(&isometry, &isometry_prior_mean.inverse()).log()
+    (isometry * isometry_prior_mean.inverse()).log()
 }
 
 impl IsResidualFn<6, 1, (), Isometry3F64, (Isometry3F64, MatF64<6, 6>)> for Isometry3PriorCostFn {
@@ -61,10 +61,10 @@ impl IsResidualFn<6, 1, (), Isometry3F64, (Isometry3F64, MatF64<6, 6>)> for Isom
 
         let residual = res_fn(isometry, isometry_prior.0);
         let dx_res_fn = |x: DualVector<6>| -> DualVector<6> {
-            let pp = Isometry3::<DualScalar, 1>::exp(&x).group_mul(&isometry.to_dual_c());
+            let pp = Isometry3::<DualScalar, 1>::exp(x) * isometry.to_dual_c();
             res_fn(
                 pp,
-                Isometry3::from_params(&DualVector::from_real_vector(*isometry_prior.0.params())),
+                Isometry3::from_params(DualVector::from_real_vector(isometry_prior.0.params())),
             )
         };
 

--- a/crates/sophus_opt/src/example_problems/cost_fn/pose_graph.rs
+++ b/crates/sophus_opt/src/example_problems/cost_fn/pose_graph.rs
@@ -14,10 +14,7 @@ pub fn res_fn<S: IsSingleScalar>(
     world_from_pose_b: Isometry2<S, 1>,
     pose_a_from_pose_b: Isometry2<S, 1>,
 ) -> S::Vector<3> {
-    (world_from_pose_a
-        .inverse()
-        .group_mul(&world_from_pose_b.group_mul(&pose_a_from_pose_b.inverse())))
-    .log()
+    (world_from_pose_a.inverse() * world_from_pose_b * pose_a_from_pose_b.inverse()).log()
 }
 
 /// Cost function for 2d pose graph
@@ -42,14 +39,14 @@ impl IsResidualFn<12, 2, (), (Isometry2F64, Isometry2F64), Isometry2F64> for Pos
         (
             || {
                 -Isometry2::dx_log_a_exp_x_b_at_0(
-                    &world_from_pose_a.inverse(),
-                    &world_from_pose_b.group_mul(&obs.inverse()),
+                    world_from_pose_a.inverse(),
+                    world_from_pose_b * obs.inverse(),
                 )
             },
             || {
                 Isometry2::dx_log_a_exp_x_b_at_0(
-                    &world_from_pose_a.inverse(),
-                    &world_from_pose_b.group_mul(&obs.inverse()),
+                    world_from_pose_a.inverse(),
+                    world_from_pose_b * obs.inverse(),
                 )
             },
         )

--- a/crates/sophus_opt/src/example_problems/cost_fn/reprojection.rs
+++ b/crates/sophus_opt/src/example_problems/cost_fn/reprojection.rs
@@ -87,10 +87,10 @@ impl IsResidualFn<13, 3, (), (PinholeCamera<f64, 1>, Isometry3F64, VecF64<3>), V
         let d1_res_fn = |x: DualVector<6>| -> DualVector<2> {
             res_fn(
                 PinholeCamera::<DualScalar, 1>::from_params_and_size(
-                    &DualVector::from_real_vector(*intrinsics.params()),
+                    DualVector::from_real_vector(*intrinsics.params()),
                     intrinsics.image_size(),
                 ),
-                Isometry3::<DualScalar, 1>::exp(&x).group_mul(&world_from_camera_pose.to_dual_c()),
+                Isometry3::<DualScalar, 1>::exp(&x) * world_from_camera_pose.to_dual_c(),
                 DualVector::from_real_vector(point_in_world),
                 DualVector::from_real_vector(*uv_in_image),
             )
@@ -99,7 +99,7 @@ impl IsResidualFn<13, 3, (), (PinholeCamera<f64, 1>, Isometry3F64, VecF64<3>), V
         let d2_res_fn = |x: DualVector<3>| -> DualVector<2> {
             res_fn(
                 PinholeCamera::<DualScalar, 1>::from_params_and_size(
-                    &DualVector::from_real_vector(*intrinsics.params()),
+                    DualVector::from_real_vector(*intrinsics.params()),
                     intrinsics.image_size(),
                 ),
                 world_from_camera_pose.to_dual_c(),

--- a/crates/sophus_opt/src/example_problems/pose_circle.rs
+++ b/crates/sophus_opt/src/example_problems/pose_circle.rs
@@ -51,7 +51,7 @@ impl PoseCircleProblem {
             let x = radius * angle.cos();
             let y = radius * angle.sin();
             let p = VecF64::<3>::from_real_array([x, y, 0.1 * angle]);
-            true_world_from_robot_poses.push(Isometry2::exp(&p));
+            true_world_from_robot_poses.push(Isometry2::exp(p));
         }
 
         for i in 0..len {
@@ -61,11 +61,8 @@ impl PoseCircleProblem {
             let true_world_from_pose_b = true_world_from_robot_poses[b_idx];
 
             let p = VecF64::<3>::from_real_array([0.001, 0.001, 0.0001]);
-            let pose_a_from_pose_b = Isometry2::exp(&p).group_mul(
-                &true_world_from_pose_a
-                    .inverse()
-                    .group_mul(&true_world_from_pose_b),
-            );
+            let pose_a_from_pose_b =
+                Isometry2::exp(p) * true_world_from_pose_a.inverse() * true_world_from_pose_b;
 
             obs_pose_a_from_pose_b_poses
                 .terms
@@ -87,8 +84,7 @@ impl PoseCircleProblem {
             let world_from_pose_a = est_world_from_robot_poses[a_idx];
             let pose_a_from_pose_b = obs.pose_a_from_pose_b;
             let p = VecF64::<3>::from_real_array([0.1, 0.1, 0.1]);
-            let world_from_pose_b =
-                Isometry2::exp(&p).group_mul(&world_from_pose_a.group_mul(&pose_a_from_pose_b));
+            let world_from_pose_b = Isometry2::exp(p) * world_from_pose_a * pose_a_from_pose_b;
 
             est_world_from_robot_poses.push(world_from_pose_b);
         }
@@ -114,7 +110,7 @@ impl PoseCircleProblem {
                 est_world_from_robot[obs.entity_indices[1]],
                 obs.pose_a_from_pose_b,
             );
-            res_err += residual.dot(residual);
+            res_err += residual.dot(&residual);
         }
         res_err /= self.obs_pose_a_from_pose_b_poses.terms.len() as f64;
         res_err

--- a/crates/sophus_opt/src/example_problems/simple_prior.rs
+++ b/crates/sophus_opt/src/example_problems/simple_prior.rs
@@ -36,7 +36,7 @@ impl Default for SimpleIso2PriorProblem {
 impl SimpleIso2PriorProblem {
     fn new() -> Self {
         let p = VecF64::<3>::from_f64_array([0.2, 0.0, 1.0]);
-        let true_world_from_robot = Isometry2::<f64, 1>::exp(&p);
+        let true_world_from_robot = Isometry2::<f64, 1>::exp(p);
         Self {
             true_world_from_robot,
             est_world_from_robot: Isometry2::<f64, 1>::identity(),
@@ -108,7 +108,7 @@ impl Default for SimpleIso3PriorProblem {
 impl SimpleIso3PriorProblem {
     fn new() -> Self {
         let p = VecF64::<6>::from_real_array([0.2, 0.0, 1.0, 0.2, 0.0, 1.0]);
-        let true_world_from_robot = Isometry3::<f64, 1>::exp(&p);
+        let true_world_from_robot = Isometry3::<f64, 1>::exp(p);
         Self {
             true_world_from_robot,
             est_world_from_robot: Isometry3::<f64, 1>::identity(),

--- a/crates/sophus_opt/src/variables.rs
+++ b/crates/sophus_opt/src/variables.rs
@@ -38,7 +38,7 @@ impl IsVariable for KannalaBrandtCamera<f64, 1> {
 
     fn update(&mut self, delta: nalgebra::DVectorView<f64>) {
         let new_params = *self.params() + delta;
-        self.set_params(&new_params);
+        self.set_params(new_params);
     }
 }
 
@@ -47,7 +47,7 @@ impl IsVariable for PinholeCamera<f64, 1> {
 
     fn update(&mut self, delta: nalgebra::DVectorView<f64>) {
         let new_params = *self.params() + delta;
-        self.set_params(&new_params);
+        self.set_params(new_params);
     }
 }
 
@@ -56,7 +56,7 @@ impl IsVariable for BrownConradyCamera<f64, 1> {
 
     fn update(&mut self, delta: nalgebra::DVectorView<f64>) {
         let new_params = *self.params() + delta;
-        self.set_params(&new_params);
+        self.set_params(new_params);
     }
 }
 
@@ -65,7 +65,7 @@ impl IsVariable for UnifiedCameraF64 {
 
     fn update(&mut self, delta: nalgebra::DVectorView<f64>) {
         let new_params = *self.params() + delta;
-        self.set_params(&new_params);
+        self.set_params(new_params);
     }
 }
 
@@ -421,10 +421,7 @@ impl IsVariable for Isometry2F64 {
         for d in 0..<Self as IsVariable>::DOF {
             delta_vec[d] = delta[d];
         }
-        self.set_params(
-            (Isometry2::<f64, 1>::group_mul(&Isometry2::<f64, 1>::exp(&delta_vec), &self.clone()))
-                .params(),
-        );
+        self.set_params((Isometry2::<f64, 1>::exp(delta_vec) * *self).params());
     }
 }
 
@@ -436,10 +433,7 @@ impl IsVariable for Isometry3F64 {
         for d in 0..<Self as IsVariable>::DOF {
             delta_vec[d] = delta[d];
         }
-        self.set_params(
-            (Isometry3::<f64, 1>::group_mul(&Isometry3::<f64, 1>::exp(&delta_vec), &self.clone()))
-                .params(),
-        );
+        self.set_params((Isometry3::<f64, 1>::exp(delta_vec) * *self).params());
     }
 }
 

--- a/crates/sophus_renderer/src/camera.rs
+++ b/crates/sophus_renderer/src/camera.rs
@@ -32,7 +32,7 @@ impl RenderCamera {
     pub fn default_from(image_size: ImageSize) -> RenderCamera {
         RenderCamera {
             properties: RenderCameraProperties::default_from(image_size),
-            scene_from_camera: Isometry3::from_translation(&VecF64::<3>::new(0.0, 0.0, -5.0)),
+            scene_from_camera: Isometry3::from_translation(VecF64::<3>::new(0.0, 0.0, -5.0)),
         }
     }
 }

--- a/crates/sophus_renderer/src/camera/intrinsics.rs
+++ b/crates/sophus_renderer/src/camera/intrinsics.rs
@@ -49,7 +49,7 @@ impl RenderIntrinsics {
         match self {
             RenderIntrinsics::Pinhole(camera) => *camera,
             RenderIntrinsics::UnifiedExtended(camera) => PinholeCameraF64::new(
-                &VecF64::<4>::from_array([
+                VecF64::<4>::from_array([
                     0.5 * camera.params()[0],
                     0.5 * camera.params()[1],
                     camera.params()[2],

--- a/crates/sophus_renderer/src/renderables/scene_renderable/axes.rs
+++ b/crates/sophus_renderer/src/renderables/scene_renderable/axes.rs
@@ -49,10 +49,10 @@ impl Axes3Builder {
         let mut lines = vec![];
 
         for world_from_local in self.world_from_local_axes.iter() {
-            let zero_in_world = world_from_local.transform(&zero_in_local);
-            let axis_x_in_world = world_from_local.transform(&x_axis_local);
-            let axis_y_in_world = world_from_local.transform(&y_axis_local);
-            let axis_z_in_world = world_from_local.transform(&z_axis_local);
+            let zero_in_world = world_from_local.transform(zero_in_local);
+            let axis_x_in_world = world_from_local.transform(x_axis_local);
+            let axis_y_in_world = world_from_local.transform(y_axis_local);
+            let axis_z_in_world = world_from_local.transform(z_axis_local);
 
             lines.push(LineSegment3 {
                 p0: zero_in_world.cast(),

--- a/crates/sophus_renderer/src/scene_renderer/line.rs
+++ b/crates/sophus_renderer/src/scene_renderer/line.rs
@@ -103,7 +103,7 @@ impl SceneLineRenderer {
                 .camera_from_entity_pose_buffer
                 .update_given_camera_and_entity(
                     &render_context.wgpu_queue,
-                    &world_from_scene.group_mul(scene_from_camera),
+                    &(world_from_scene * scene_from_camera),
                     &line.world_from_entity,
                 );
             render_pass.set_vertex_buffer(0, line.vertex_buffer.slice(..));

--- a/crates/sophus_renderer/src/scene_renderer/mesh.rs
+++ b/crates/sophus_renderer/src/scene_renderer/mesh.rs
@@ -114,7 +114,7 @@ impl MeshRenderer {
                 .camera_from_entity_pose_buffer
                 .update_given_camera_and_entity(
                     &render_context.wgpu_queue,
-                    &world_from_scene.group_mul(scene_from_camera),
+                    &(world_from_scene * scene_from_camera),
                     &mesh.world_from_entity,
                 );
             render_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));

--- a/crates/sophus_renderer/src/scene_renderer/point.rs
+++ b/crates/sophus_renderer/src/scene_renderer/point.rs
@@ -89,7 +89,7 @@ impl ScenePointRenderer {
                 .camera_from_entity_pose_buffer
                 .update_given_camera_and_entity(
                     &render_context.wgpu_queue,
-                    &world_from_scene.group_mul(scene_from_camera),
+                    &(world_from_scene * scene_from_camera),
                     &point.world_from_entity,
                 );
             render_pass.set_vertex_buffer(0, point.vertex_buffer.slice(..));

--- a/crates/sophus_renderer/src/scene_renderer/textured_mesh.rs
+++ b/crates/sophus_renderer/src/scene_renderer/textured_mesh.rs
@@ -201,7 +201,7 @@ impl TexturedMeshRenderer {
                 .camera_from_entity_pose_buffer
                 .update_given_camera_and_entity(
                     &render_context.wgpu_queue,
-                    &world_from_scene.group_mul(scene_from_camera),
+                    &(world_from_scene * scene_from_camera),
                     &mesh._scene_from_entity,
                 );
             render_pass.set_bind_group(1, &mesh._texture_bind_group, &[]);

--- a/crates/sophus_renderer/src/uniform_buffers.rs
+++ b/crates/sophus_renderer/src/uniform_buffers.rs
@@ -57,8 +57,7 @@ impl CameraFromEntityPoseUniform {
         scene_from_camera: &Isometry3F64,
         world_from_entity: &Isometry3F64,
     ) {
-        let camera_from_entity_mat4x4 =
-            (scene_from_camera.inverse().group_mul(world_from_entity)).matrix();
+        let camera_from_entity_mat4x4 = (scene_from_camera.inverse() * world_from_entity).matrix();
 
         let mut camera_from_entity_uniform: [[f32; 4]; 4] = [[0.0; 4]; 4];
         for i in 0..4 {

--- a/crates/sophus_sensor/src/camera_enum/perspective_camera.rs
+++ b/crates/sophus_sensor/src/camera_enum/perspective_camera.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use crate::distortions::affine::AffineDistortionImpl;
 use crate::distortions::brown_conrady::BrownConradyDistortionImpl;
 use crate::distortions::kannala_brandt::KannalaBrandtDistortionImpl;
@@ -54,25 +56,39 @@ pub enum PerspectiveCameraEnum<S: IsScalar<BATCH>, const BATCH: usize> {
     UnifiedExtended(UnifiedCamera<S, BATCH>),
 }
 
-impl<S: IsScalar<BATCH>, const BATCH: usize> IsCameraEnum<S, BATCH>
+impl<S: IsScalar<BATCH>, const BATCH: usize> IsCamera<S, BATCH>
     for PerspectiveCameraEnum<S, BATCH>
 {
-    fn new_pinhole(params: &S::Vector<4>, image_size: ImageSize) -> Self {
-        Self::Pinhole(PinholeCamera::from_params_and_size(params, image_size))
+    fn new_pinhole<P>(params: P, image_size: ImageSize) -> Self
+    where
+        P: Borrow<S::Vector<4>>,
+    {
+        let params = params.borrow();
+        PerspectiveCameraEnum::Pinhole(PinholeCamera::new(params, image_size))
     }
 
-    fn new_kannala_brandt(params: &S::Vector<8>, image_size: ImageSize) -> Self {
-        Self::KannalaBrandt(KannalaBrandtCamera::from_params_and_size(
-            params, image_size,
-        ))
+    fn new_kannala_brandt<P>(params: P, image_size: ImageSize) -> Self
+    where
+        P: Borrow<S::Vector<8>>,
+    {
+        let params = params.borrow();
+        PerspectiveCameraEnum::KannalaBrandt(KannalaBrandtCamera::new(params, image_size))
     }
 
-    fn new_brown_conrady(params: &S::Vector<12>, image_size: ImageSize) -> Self {
-        Self::BrownConrady(BrownConradyCamera::from_params_and_size(params, image_size))
+    fn new_brown_conrady<P>(params: P, image_size: ImageSize) -> Self
+    where
+        P: Borrow<S::Vector<12>>,
+    {
+        let params = params.borrow();
+        PerspectiveCameraEnum::BrownConrady(BrownConradyCamera::new(params, image_size))
     }
 
-    fn new_unified(params: &<S as IsScalar<BATCH>>::Vector<6>, image_size: ImageSize) -> Self {
-        Self::UnifiedExtended(UnifiedCamera::from_params_and_size(params, image_size))
+    fn new_unified<P>(params: P, image_size: ImageSize) -> Self
+    where
+        P: Borrow<S::Vector<6>>,
+    {
+        let params = params.borrow();
+        PerspectiveCameraEnum::UnifiedExtended(UnifiedCamera::new(params, image_size))
     }
 
     fn image_size(&self) -> ImageSize {
@@ -84,7 +100,12 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsCameraEnum<S, BATCH>
         }
     }
 
-    fn cam_proj(&self, point_in_camera: &S::Vector<3>) -> S::Vector<2> {
+    fn cam_proj<P>(&self, point_in_camera: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<3>>,
+    {
+        let point_in_camera = point_in_camera.borrow();
+
         match self {
             PerspectiveCameraEnum::Pinhole(camera) => camera.cam_proj(point_in_camera),
             PerspectiveCameraEnum::KannalaBrandt(camera) => camera.cam_proj(point_in_camera),
@@ -93,97 +114,119 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsCameraEnum<S, BATCH>
         }
     }
 
-    fn cam_unproj_with_z(&self, point_in_camera: &S::Vector<2>, z: S) -> S::Vector<3> {
+    fn cam_unproj_with_z<P>(&self, pixel: P, z: S) -> S::Vector<3>
+    where
+        P: Borrow<S::Vector<2>>,
+    {
+        let pixel = pixel.borrow();
         match self {
-            PerspectiveCameraEnum::Pinhole(camera) => camera.cam_unproj_with_z(point_in_camera, z),
+            PerspectiveCameraEnum::Pinhole(camera) => camera.cam_unproj_with_z(pixel, z),
+            PerspectiveCameraEnum::KannalaBrandt(camera) => camera.cam_unproj_with_z(pixel, z),
+            PerspectiveCameraEnum::BrownConrady(camera) => camera.cam_unproj_with_z(pixel, z),
+            PerspectiveCameraEnum::UnifiedExtended(camera) => camera.cam_unproj_with_z(pixel, z),
+        }
+    }
+
+    fn distort<P>(&self, proj_point_in_camera_z1_plane: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<2>>,
+    {
+        let proj_point_in_camera_z1_plane = proj_point_in_camera_z1_plane.borrow();
+        match self {
+            PerspectiveCameraEnum::Pinhole(camera) => camera.distort(proj_point_in_camera_z1_plane),
             PerspectiveCameraEnum::KannalaBrandt(camera) => {
-                camera.cam_unproj_with_z(point_in_camera, z)
+                camera.distort(proj_point_in_camera_z1_plane)
             }
             PerspectiveCameraEnum::BrownConrady(camera) => {
-                camera.cam_unproj_with_z(point_in_camera, z)
+                camera.distort(proj_point_in_camera_z1_plane)
             }
             PerspectiveCameraEnum::UnifiedExtended(camera) => {
-                camera.cam_unproj_with_z(point_in_camera, z)
+                camera.distort(proj_point_in_camera_z1_plane)
             }
         }
     }
 
-    fn distort(&self, point_in_camera: &S::Vector<2>) -> S::Vector<2> {
+    fn undistort<P>(&self, pixel: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<2>>,
+    {
+        let pixel = pixel.borrow();
         match self {
-            PerspectiveCameraEnum::Pinhole(camera) => camera.distort(point_in_camera),
-            PerspectiveCameraEnum::KannalaBrandt(camera) => camera.distort(point_in_camera),
-            PerspectiveCameraEnum::BrownConrady(camera) => camera.distort(point_in_camera),
-            PerspectiveCameraEnum::UnifiedExtended(camera) => camera.distort(point_in_camera),
+            PerspectiveCameraEnum::Pinhole(camera) => camera.undistort(pixel),
+            PerspectiveCameraEnum::KannalaBrandt(camera) => camera.undistort(pixel),
+            PerspectiveCameraEnum::BrownConrady(camera) => camera.undistort(pixel),
+            PerspectiveCameraEnum::UnifiedExtended(camera) => camera.undistort(pixel),
         }
     }
 
-    fn undistort(&self, point_in_camera: &S::Vector<2>) -> S::Vector<2> {
+    fn dx_distort_x<P>(&self, proj_point_in_camera_z1_plane: P) -> S::Matrix<2, 2>
+    where
+        P: Borrow<S::Vector<2>>,
+    {
+        let proj_point_in_camera_z1_plane = proj_point_in_camera_z1_plane.borrow();
         match self {
-            PerspectiveCameraEnum::Pinhole(camera) => camera.undistort(point_in_camera),
-            PerspectiveCameraEnum::KannalaBrandt(camera) => camera.undistort(point_in_camera),
-            PerspectiveCameraEnum::BrownConrady(camera) => camera.undistort(point_in_camera),
-            PerspectiveCameraEnum::UnifiedExtended(camera) => camera.undistort(point_in_camera),
-        }
-    }
-
-    fn dx_distort_x(&self, point_in_camera: &S::Vector<2>) -> S::Matrix<2, 2> {
-        match self {
-            PerspectiveCameraEnum::Pinhole(camera) => camera.dx_distort_x(point_in_camera),
-            PerspectiveCameraEnum::KannalaBrandt(camera) => camera.dx_distort_x(point_in_camera),
-            PerspectiveCameraEnum::BrownConrady(camera) => camera.dx_distort_x(point_in_camera),
-            PerspectiveCameraEnum::UnifiedExtended(camera) => camera.dx_distort_x(point_in_camera),
+            PerspectiveCameraEnum::Pinhole(camera) => {
+                camera.dx_distort_x(proj_point_in_camera_z1_plane)
+            }
+            PerspectiveCameraEnum::KannalaBrandt(camera) => {
+                camera.dx_distort_x(proj_point_in_camera_z1_plane)
+            }
+            PerspectiveCameraEnum::BrownConrady(camera) => {
+                camera.dx_distort_x(proj_point_in_camera_z1_plane)
+            }
+            PerspectiveCameraEnum::UnifiedExtended(camera) => {
+                camera.dx_distort_x(proj_point_in_camera_z1_plane)
+            }
         }
     }
 
     fn try_get_brown_conrady(self) -> Option<BrownConradyCamera<S, BATCH>> {
-        match self {
-            PerspectiveCameraEnum::Pinhole(_) => None,
-            PerspectiveCameraEnum::KannalaBrandt(_) => None,
-            PerspectiveCameraEnum::BrownConrady(camera) => Some(camera),
-            PerspectiveCameraEnum::UnifiedExtended(_) => None,
+        if let PerspectiveCameraEnum::BrownConrady(camera) = self {
+            Some(camera)
+        } else {
+            None
         }
     }
 
     fn try_get_kannala_brandt(self) -> Option<KannalaBrandtCamera<S, BATCH>> {
-        match self {
-            PerspectiveCameraEnum::Pinhole(_) => None,
-            PerspectiveCameraEnum::KannalaBrandt(camera) => Some(camera),
-            PerspectiveCameraEnum::BrownConrady(_) => None,
-            PerspectiveCameraEnum::UnifiedExtended(_) => None,
+        if let PerspectiveCameraEnum::KannalaBrandt(camera) = self {
+            Some(camera)
+        } else {
+            None
         }
     }
 
     fn try_get_pinhole(self) -> Option<PinholeCamera<S, BATCH>> {
-        match self {
-            PerspectiveCameraEnum::Pinhole(camera) => Some(camera),
-            PerspectiveCameraEnum::KannalaBrandt(_) => None,
-            PerspectiveCameraEnum::BrownConrady(_) => None,
-            PerspectiveCameraEnum::UnifiedExtended(_) => None,
+        if let PerspectiveCameraEnum::Pinhole(camera) = self {
+            Some(camera)
+        } else {
+            None
         }
     }
 
     fn try_get_unified_extended(self) -> Option<UnifiedCamera<S, BATCH>> {
-        match self {
-            PerspectiveCameraEnum::Pinhole(_) => None,
-            PerspectiveCameraEnum::KannalaBrandt(_) => None,
-            PerspectiveCameraEnum::BrownConrady(_) => None,
-            PerspectiveCameraEnum::UnifiedExtended(camera) => Some(camera),
+        if let PerspectiveCameraEnum::UnifiedExtended(camera) = self {
+            Some(camera)
+        } else {
+            None
         }
     }
 }
 
-impl<S: IsScalar<BATCH>, const BATCH: usize> IsPerspectiveCameraEnum<S, BATCH>
+impl<S: IsScalar<BATCH>, const BATCH: usize> IsPerspectiveCamera<S, BATCH>
     for PerspectiveCameraEnum<S, BATCH>
 {
     fn pinhole_params(&self) -> S::Vector<4> {
         match self {
             PerspectiveCameraEnum::Pinhole(camera) => camera.params().clone(),
             PerspectiveCameraEnum::KannalaBrandt(camera) => {
-                camera.params().get_fixed_subvec::<4>(0)
+                camera.params().clone().get_fixed_subvec(0)
             }
-            PerspectiveCameraEnum::BrownConrady(camera) => camera.params().get_fixed_subvec::<4>(0),
+            PerspectiveCameraEnum::BrownConrady(camera) => {
+                camera.params().clone().get_fixed_subvec(0)
+            }
             PerspectiveCameraEnum::UnifiedExtended(camera) => {
-                camera.params().get_fixed_subvec::<4>(0)
+                camera.params().clone().get_fixed_subvec(0)
             }
         }
     }

--- a/crates/sophus_sensor/src/distortion_table.rs
+++ b/crates/sophus_sensor/src/distortion_table.rs
@@ -61,16 +61,16 @@ pub fn distort_table(cam: &DynCamera<f64, 1>) -> DistortTable {
     for i in 0..=cam.image_size().width {
         let u = i as f64 - 0.5;
         // top border
-        region.extend(&cam.undistort(&VecF64::<2>::new(u, v_top)));
+        region.extend(&cam.undistort(VecF64::<2>::new(u, v_top)));
         // bottom border
-        region.extend(&cam.undistort(&VecF64::<2>::new(u, v_bottom)));
+        region.extend(&cam.undistort(VecF64::<2>::new(u, v_bottom)));
     }
     for i in 0..=cam.image_size().height {
         let v = i as f64 - 0.5;
         // left border
-        region.extend(&cam.undistort(&VecF64::<2>::new(u_left, v)));
+        region.extend(&cam.undistort(VecF64::<2>::new(u_left, v)));
         // right border
-        region.extend(&cam.undistort(&VecF64::<2>::new(u_right, v)));
+        region.extend(&cam.undistort(VecF64::<2>::new(u_right, v)));
     }
 
     let mid = region.mid();
@@ -91,7 +91,7 @@ pub fn distort_table(cam: &DynCamera<f64, 1>) -> DistortTable {
                 distort_table.offset().x + (u as f64) * distort_table.incr().x,
                 distort_table.offset().y + (v as f64) * distort_table.incr().y,
             );
-            let pixel = cam.distort(&point_proj);
+            let pixel = cam.distort(point_proj);
             *table.mut_pixel(u, v) = SVector::<f32, 2>::new(pixel.cast().x, pixel.cast().y);
         }
     }
@@ -115,7 +115,7 @@ fn camera_distortion_table_tests() {
     {
         let mut cameras: alloc::vec::Vec<DynCameraF64> = alloc::vec![];
         cameras.push(DynCameraF64::new_pinhole(
-            &VecF64::<4>::new(600.0, 600.0, 1.0, 0.5),
+            VecF64::<4>::new(600.0, 600.0, 1.0, 0.5),
             ImageSize {
                 width: 3,
                 height: 2,
@@ -123,7 +123,7 @@ fn camera_distortion_table_tests() {
         ));
 
         cameras.push(DynCamera::new_kannala_brandt(
-            &VecF64::<8>::from_vec(alloc::vec![
+            VecF64::<8>::from_vec(alloc::vec![
                 1000.0, 1000.0, 320.0, 280.0, 0.1, 0.01, 0.001, 0.0001
             ]),
             ImageSize {
@@ -155,20 +155,20 @@ fn camera_distortion_table_tests() {
                 }
 
                 for d in [1.0, 0.1, 0.5, 1.1, 3.0, 15.0] {
-                    let point_in_camera = camera.cam_unproj_with_z(&pixel, d);
+                    let point_in_camera = camera.cam_unproj_with_z(pixel, d);
                     assert_relative_eq!(point_in_camera[2], d, epsilon = EPS_F64);
 
-                    let pixel_in_image2 = camera.cam_proj(&point_in_camera);
+                    let pixel_in_image2 = camera.cam_proj(point_in_camera);
                     assert_relative_eq!(pixel_in_image2, pixel, epsilon = EPS_F64);
                 }
-                let ab_in_z1plane = camera.undistort(&pixel);
+                let ab_in_z1plane = camera.undistort(pixel);
 
-                let pixel_in_image3 = camera.distort(&ab_in_z1plane);
+                let pixel_in_image3 = camera.distort(ab_in_z1plane);
                 assert_relative_eq!(pixel_in_image3, pixel, epsilon = EPS_F64);
 
-                let dx = camera.dx_distort_x(&pixel);
+                let dx = camera.dx_distort_x(pixel);
                 let numeric_dx = VectorValuedMapFromVector::static_sym_diff_quotient(
-                    |x: VecF64<2>| camera.distort(&x),
+                    |x: VecF64<2>| camera.distort(x),
                     pixel,
                     EPS_F64,
                 );
@@ -184,8 +184,8 @@ fn camera_distortion_table_tests() {
                 {
                     continue;
                 }
-                let proj = camera.undistort(&pixel);
-                let analytic_pixel = camera.distort(&proj);
+                let proj = camera.undistort(pixel);
+                let analytic_pixel = camera.distort(proj);
                 let lut_pixel = table.lookup(&proj);
 
                 assert_abs_diff_eq!(analytic_pixel, pixel, epsilon = 1e-3);

--- a/crates/sophus_sensor/src/distortions/kannala_brandt.rs
+++ b/crates/sophus_sensor/src/distortions/kannala_brandt.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::traits::IsCameraDistortionImpl;
+use core::borrow::Borrow;
 use core::marker::PhantomData;
 use sophus_core::linalg::EPS_F64;
 use sophus_core::params::ParamsImpl;
@@ -15,7 +16,10 @@ pub struct KannalaBrandtDistortionImpl<S: IsScalar<BATCH>, const BATCH: usize> {
 impl<S: IsScalar<BATCH>, const BATCH: usize> ParamsImpl<S, 8, BATCH>
     for KannalaBrandtDistortionImpl<S, BATCH>
 {
-    fn are_params_valid(_params: &S::Vector<8>) -> S::Mask {
+    fn are_params_valid<P>(_params: P) -> S::Mask
+    where
+        P: Borrow<S::Vector<8>>,
+    {
         S::Mask::all_true()
     }
 
@@ -36,10 +40,14 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> ParamsImpl<S, 8, BATCH>
 impl<S: IsScalar<BATCH>, const BATCH: usize> IsCameraDistortionImpl<S, 4, 8, BATCH>
     for KannalaBrandtDistortionImpl<S, BATCH>
 {
-    fn distort(
-        params: &S::Vector<8>,
-        proj_point_in_camera_z1_plane: &S::Vector<2>,
-    ) -> S::Vector<2> {
+    fn distort<PA, PO>(params: PA, proj_point_in_camera_z1_plane: PO) -> S::Vector<2>
+    where
+        PA: Borrow<S::Vector<8>>,
+        PO: Borrow<S::Vector<2>>,
+    {
+        let params = params.borrow();
+        let proj_point_in_camera_z1_plane = proj_point_in_camera_z1_plane.borrow();
+
         let k0 = params.get_elem(4);
         let k1 = params.get_elem(5);
         let k2 = params.get_elem(6);
@@ -73,7 +81,13 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsCameraDistortionImpl<S, 4, 8, BAT
         ])
     }
 
-    fn undistort(params: &S::Vector<8>, distorted_point: &S::Vector<2>) -> S::Vector<2> {
+    fn undistort<PA, PO>(params: PA, distorted_point: PO) -> S::Vector<2>
+    where
+        PA: Borrow<S::Vector<8>>,
+        PO: Borrow<S::Vector<2>>,
+    {
+        let params = params.borrow();
+        let distorted_point = distorted_point.borrow();
         let fu = params.get_elem(0);
         let fv = params.get_elem(1);
         let u0 = params.get_elem(2);
@@ -149,10 +163,14 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsCameraDistortionImpl<S, 4, 8, BAT
         )
     }
 
-    fn dx_distort_x(
-        params: &S::Vector<8>,
-        proj_point_in_camera_z1_plane: &S::Vector<2>,
-    ) -> S::Matrix<2, 2> {
+    fn dx_distort_x<PA, PO>(params: PA, proj_point_in_camera_z1_plane: PO) -> S::Matrix<2, 2>
+    where
+        PA: Borrow<S::Vector<8>>,
+        PO: Borrow<S::Vector<2>>,
+    {
+        let params = params.borrow();
+        let proj_point_in_camera_z1_plane = proj_point_in_camera_z1_plane.borrow();
+
         let a = proj_point_in_camera_z1_plane.get_elem(0);
         let b = proj_point_in_camera_z1_plane.get_elem(1);
         let fx = params.get_elem(0);
@@ -221,10 +239,14 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsCameraDistortionImpl<S, 4, 8, BAT
         dx0.select(&near_zero, dx)
     }
 
-    fn dx_distort_params(
-        params: &S::Vector<8>,
-        proj_point_in_camera_z1_plane: &S::Vector<2>,
-    ) -> S::Matrix<2, 8> {
+    fn dx_distort_params<PA, PO>(params: PA, proj_point_in_camera_z1_plane: PO) -> S::Matrix<2, 8>
+    where
+        PA: Borrow<S::Vector<8>>,
+        PO: Borrow<S::Vector<2>>,
+    {
+        let params = params.borrow();
+        let proj_point_in_camera_z1_plane = proj_point_in_camera_z1_plane.borrow();
+
         let x = proj_point_in_camera_z1_plane.get_elem(0);
         let y = proj_point_in_camera_z1_plane.get_elem(1);
         let fx = params.get_elem(0);

--- a/crates/sophus_sensor/src/lib.rs
+++ b/crates/sophus_sensor/src/lib.rs
@@ -32,8 +32,8 @@ pub mod traits;
 
 /// sophus sensor prelude
 pub mod prelude {
-    pub use crate::traits::IsCameraEnum;
-    pub use crate::traits::IsPerspectiveCameraEnum;
+    pub use crate::traits::IsCamera;
+    pub use crate::traits::IsPerspectiveCamera;
     pub use crate::traits::IsProjection;
     pub use sophus_core::prelude::*;
 }

--- a/crates/sophus_sensor/src/projections/orthographic.rs
+++ b/crates/sophus_sensor/src/projections/orthographic.rs
@@ -1,6 +1,7 @@
 use crate::camera::Camera;
 use crate::distortions::affine::AffineDistortionImpl;
 use crate::traits::IsProjection;
+use core::borrow::Borrow;
 use core::marker::PhantomData;
 use sophus_core::linalg::scalar::IsScalar;
 use sophus_core::linalg::vector::IsVector;
@@ -14,11 +15,18 @@ pub struct OrthographisProjectionImpl<S: IsScalar<BATCH>, const BATCH: usize> {
 impl<S: IsScalar<BATCH>, const BATCH: usize> IsProjection<S, BATCH>
     for OrthographisProjectionImpl<S, BATCH>
 {
-    fn proj(point_in_camera: &S::Vector<3>) -> S::Vector<2> {
-        point_in_camera.get_fixed_subvec::<2>(0)
+    fn proj<P>(point_in_camera: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<3>>,
+    {
+        point_in_camera.borrow().get_fixed_subvec::<2>(0)
     }
 
-    fn unproj(point_in_camera: &S::Vector<2>, extension: S) -> S::Vector<3> {
+    fn unproj<P>(point_in_camera: P, extension: S) -> S::Vector<3>
+    where
+        P: Borrow<S::Vector<2>>,
+    {
+        let point_in_camera = point_in_camera.borrow();
         S::Vector::<3>::from_array([
             point_in_camera.get_elem(0),
             point_in_camera.get_elem(1),
@@ -26,7 +34,10 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsProjection<S, BATCH>
         ])
     }
 
-    fn dx_proj_x(_point_in_camera: &S::Vector<3>) -> S::Matrix<2, 3> {
+    fn dx_proj_x<P>(_point_in_camera: P) -> S::Matrix<2, 3>
+    where
+        P: Borrow<S::Vector<3>>,
+    {
         unimplemented!("dx_proj_x not implemented for ProjectionOrtho")
     }
 }

--- a/crates/sophus_sensor/src/projections/perspective.rs
+++ b/crates/sophus_sensor/src/projections/perspective.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use crate::traits::IsProjection;
 use sophus_core::linalg::matrix::IsMatrix;
 use sophus_core::linalg::scalar::IsScalar;
@@ -15,14 +17,23 @@ pub struct PerspectiveProjectionImpl<S: IsScalar<BATCH>, const BATCH: usize> {
 impl<S: IsScalar<BATCH>, const BATCH: usize> IsProjection<S, BATCH>
     for PerspectiveProjectionImpl<S, BATCH>
 {
-    fn proj(point_in_camera: &S::Vector<3>) -> S::Vector<2> {
+    fn proj<P>(point_in_camera: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<3>>,
+    {
+        let point_in_camera = point_in_camera.borrow();
         S::Vector::<2>::from_array([
             point_in_camera.get_elem(0) / point_in_camera.get_elem(2),
             point_in_camera.get_elem(1) / point_in_camera.get_elem(2),
         ])
     }
 
-    fn unproj(point_in_camera: &S::Vector<2>, extension: S) -> S::Vector<3> {
+    fn unproj<P>(point_in_camera: P, extension: S) -> S::Vector<3>
+    where
+        P: Borrow<S::Vector<2>>,
+    {
+        let point_in_camera = point_in_camera.borrow();
+
         S::Vector::<3>::from_array([
             point_in_camera.get_elem(0) * extension.clone(),
             point_in_camera.get_elem(1) * extension.clone(),
@@ -30,7 +41,12 @@ impl<S: IsScalar<BATCH>, const BATCH: usize> IsProjection<S, BATCH>
         ])
     }
 
-    fn dx_proj_x(point_in_camera: &S::Vector<3>) -> S::Matrix<2, 3> {
+    fn dx_proj_x<P>(point_in_camera: P) -> S::Matrix<2, 3>
+    where
+        P: Borrow<S::Vector<3>>,
+    {
+        let point_in_camera = point_in_camera.borrow();
+
         S::Matrix::<2, 3>::from_array2([
             [
                 S::ones() / point_in_camera.get_elem(2),

--- a/crates/sophus_sensor/src/traits.rs
+++ b/crates/sophus_sensor/src/traits.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use crate::camera_enum::perspective_camera::UnifiedCamera;
 use crate::prelude::*;
 use crate::BrownConradyCamera;
@@ -23,63 +25,93 @@ pub trait IsCameraDistortionImpl<
     }
 
     /// Distortion - maps a point in the camera z=1 plane to a distorted point
-    fn distort(
-        params: &S::Vector<PARAMS>,
-        proj_point_in_camera_z1_plane: &S::Vector<2>,
-    ) -> S::Vector<2>;
+    fn distort<PA, PO>(params: PA, proj_point_in_camera_z1_plane: PO) -> S::Vector<2>
+    where
+        PA: Borrow<S::Vector<PARAMS>>,
+        PO: Borrow<S::Vector<2>>;
 
     /// Undistortion - maps a distorted pixel to a point in the camera z=1 plane
-    fn undistort(params: &S::Vector<PARAMS>, distorted_point: &S::Vector<2>) -> S::Vector<2>;
+    fn undistort<PA, PO>(params: PA, distorted_point: PO) -> S::Vector<2>
+    where
+        PA: Borrow<S::Vector<PARAMS>>,
+        PO: Borrow<S::Vector<2>>;
 
     /// Derivative of the distortion w.r.t. the point in the camera z=1 plane
-    fn dx_distort_x(
-        params: &S::Vector<PARAMS>,
-        proj_point_in_camera_z1_plane: &S::Vector<2>,
-    ) -> S::Matrix<2, 2>;
+    fn dx_distort_x<PA, PO>(params: PA, proj_point_in_camera_z1_plane: PO) -> S::Matrix<2, 2>
+    where
+        PA: Borrow<S::Vector<PARAMS>>,
+        PO: Borrow<S::Vector<2>>;
 
     /// Derivative of the distortion w.r.t. the parameters
-    fn dx_distort_params(
-        params: &S::Vector<PARAMS>,
-        proj_point_in_camera_z1_plane: &S::Vector<2>,
-    ) -> S::Matrix<2, PARAMS>;
+    fn dx_distort_params<PA, PO>(
+        params: PA,
+        proj_point_in_camera_z1_plane: PO,
+    ) -> S::Matrix<2, PARAMS>
+    where
+        PA: Borrow<S::Vector<PARAMS>>,
+        PO: Borrow<S::Vector<2>>;
 }
 
 /// Camera projection implementation trait
 pub trait IsProjection<S: IsScalar<BATCH>, const BATCH: usize> {
     /// Projects a 3D point in the camera frame to a 2D point in the z=1 plane
-    fn proj(point_in_camera: &S::Vector<3>) -> S::Vector<2>;
+    fn proj<P>(point_in_camera: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<3>>;
 
     /// Unprojects a 2D point in the z=1 plane to a 3D point in the camera frame
-    fn unproj(point_in_camera: &S::Vector<2>, extension: S) -> S::Vector<3>;
+    fn unproj<P>(point_in_camera: P, extension: S) -> S::Vector<3>
+    where
+        P: Borrow<S::Vector<2>>;
 
     /// Derivative of the projection w.r.t. the point in the camera frame
-    fn dx_proj_x(point_in_camera: &S::Vector<3>) -> S::Matrix<2, 3>;
+    fn dx_proj_x<P>(point_in_camera: P) -> S::Matrix<2, 3>
+    where
+        P: Borrow<S::Vector<3>>;
 }
 
 /// Camera trait
-pub trait IsCameraEnum<S: IsScalar<BATCH>, const BATCH: usize> {
+pub trait IsCamera<S: IsScalar<BATCH>, const BATCH: usize> {
     /// Creates a new pinhole camera
-    fn new_pinhole(params: &S::Vector<4>, image_size: ImageSize) -> Self;
+    fn new_pinhole<P>(params: P, image_size: ImageSize) -> Self
+    where
+        P: Borrow<S::Vector<4>>;
     /// Creates a new Kannala-Brandt camera
-    fn new_kannala_brandt(params: &S::Vector<8>, image_size: ImageSize) -> Self;
+    fn new_kannala_brandt<P>(params: P, image_size: ImageSize) -> Self
+    where
+        P: Borrow<S::Vector<8>>;
     /// Creates a new Brown-Conrady camera
-    fn new_brown_conrady(params: &S::Vector<12>, image_size: ImageSize) -> Self;
+    fn new_brown_conrady<P>(params: P, image_size: ImageSize) -> Self
+    where
+        P: Borrow<S::Vector<12>>;
     /// Creates a new Unified Extended camera
-    fn new_unified(params: &S::Vector<6>, image_size: ImageSize) -> Self;
+    fn new_unified<P>(params: P, image_size: ImageSize) -> Self
+    where
+        P: Borrow<S::Vector<6>>;
 
     /// Returns the image size
     fn image_size(&self) -> ImageSize;
 
     /// Projects a 3D point in the camera frame to a pixel in the image
-    fn cam_proj(&self, point_in_camera: &S::Vector<3>) -> S::Vector<2>;
+    fn cam_proj<P>(&self, point_in_camera: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<3>>;
     /// Unprojects a pixel in the image to a 3D point in the camera frame
-    fn cam_unproj_with_z(&self, pixel: &S::Vector<2>, z: S) -> S::Vector<3>;
+    fn cam_unproj_with_z<P>(&self, pixel: P, z: S) -> S::Vector<3>
+    where
+        P: Borrow<S::Vector<2>>;
     /// Distortion - maps a point in the camera z=1 plane to a distorted point
-    fn distort(&self, proj_point_in_camera_z1_plane: &S::Vector<2>) -> S::Vector<2>;
+    fn distort<P>(&self, proj_point_in_camera_z1_plane: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<2>>;
     /// Undistortion - maps a distorted pixel to a point in the camera z=1 plane
-    fn undistort(&self, pixel: &S::Vector<2>) -> S::Vector<2>;
+    fn undistort<P>(&self, pixel: P) -> S::Vector<2>
+    where
+        P: Borrow<S::Vector<2>>;
     /// Derivative of the distortion w.r.t. the point in the camera z=1 plane
-    fn dx_distort_x(&self, proj_point_in_camera_z1_plane: &S::Vector<2>) -> S::Matrix<2, 2>;
+    fn dx_distort_x<P>(&self, proj_point_in_camera_z1_plane: P) -> S::Matrix<2, 2>
+    where
+        P: Borrow<S::Vector<2>>;
 
     /// Returns the brown-conrady camera
     fn try_get_brown_conrady(self) -> Option<BrownConradyCamera<S, BATCH>>;
@@ -95,7 +127,7 @@ pub trait IsCameraEnum<S: IsScalar<BATCH>, const BATCH: usize> {
 }
 
 /// Dynamic camera trait
-pub trait IsPerspectiveCameraEnum<S: IsScalar<BATCH>, const BATCH: usize> {
+pub trait IsPerspectiveCamera<S: IsScalar<BATCH>, const BATCH: usize> {
     /// Return the first four parameters: fx, fy, cx, cy
     fn pinhole_params(&self) -> S::Vector<4>;
 }

--- a/crates/sophus_viewer/src/interactions/inplane_interaction.rs
+++ b/crates/sophus_viewer/src/interactions/inplane_interaction.rs
@@ -102,7 +102,7 @@ impl InplaneInteraction {
 
     /// scene_from_camera - always the identity
     pub fn scene_from_camera(&self) -> Isometry3F64 {
-        Isometry3::from_translation(&VecF64::<3>::new(0.0, 0.0, 0.0))
+        Isometry3::from_translation(VecF64::<3>::new(0.0, 0.0, 0.0))
     }
 
     /// zoom

--- a/justfile
+++ b/justfile
@@ -13,8 +13,11 @@ build-std:
 build-simd:
     cargo +nightly build --release --all-targets --features simd
 
+test-simd:
+    cargo +nightly test --release --features simd
+
 test:
-    cargo +nightly test --release
+    cargo test --release
 
 format:
     pre-commit run -a


### PR DESCRIPTION
 - add Mul operator for group multiplication (on vales and &)
 - make use of Borrow trait for generic types (which are not Copy in general) 

**examples:**

```
let true_cam1_from_cam0 =
     true_world_from_cameras[1].inverse() * true_world_from_cameras[0];
 ```
 
vs
 
 ```
let true_cam2_from_cam0 = 
    true_world_from_cameras[2].inverse().group_mul(&true_world_from_cameras[0]);
```

and

```
res_fn(
    Isometry3::<DualScalar, 1>::exp(x) * isometry.to_dual_c()
    Isometry3::from_params(DualVector::from_real_vector(isometry_prior.0.params())),
)
````

vs.

```
res_fn(
    Isometry3::<DualScalar, 1>::exp(&x).group_mul(&isometry.to_dual_c()),
    Isometry3::from_params(&DualVector::from_real_vector(*isometry_prior.0.params())),
)
````


