### PR TITLE
Enable automatic feature annotations in docs

### DIFF
--- a/crates/sophus/src/lib.rs
+++ b/crates/sophus/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "simd", feature(portable_simd))]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 
 #[doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]

--- a/crates/sophus_autodiff/Cargo.toml
+++ b/crates/sophus_autodiff/Cargo.toml
@@ -27,3 +27,6 @@ rustc_version.workspace = true
 default = ["std"]
 simd = ["sleef"]
 std = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_autodiff/src/lib.rs
+++ b/crates/sophus_autodiff/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_geo/Cargo.toml
+++ b/crates/sophus_geo/Cargo.toml
@@ -23,3 +23,6 @@ rustc_version.workspace = true
 simd = ["sophus_lie/simd"]
 std = ["sophus_autodiff/std", "sophus_lie/std"]
 default = ["std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_geo/src/lib.rs
+++ b/crates/sophus_geo/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/crates/sophus_image/Cargo.toml
+++ b/crates/sophus_image/Cargo.toml
@@ -29,3 +29,6 @@ rustc_version.workspace = true
 simd = ["sophus_tensor/simd"]
 std = ["png", "tiff", "sophus_autodiff/std", "sophus_tensor/std"]
 default = ["std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_image/src/lib.rs
+++ b/crates/sophus_image/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 #![no_std]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_lie/Cargo.toml
+++ b/crates/sophus_lie/Cargo.toml
@@ -28,3 +28,6 @@ rustc_version.workspace = true
 default = ["std"]
 simd = ["sophus_autodiff/simd"]
 std = ["sophus_autodiff/std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_lie/src/lib.rs
+++ b/crates/sophus_lie/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::needless_range_loop)]
 #![no_std]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_opt/Cargo.toml
+++ b/crates/sophus_opt/Cargo.toml
@@ -48,3 +48,6 @@ std = [
   "sophus_lie/std",
   "sophus_sensor/std",
 ]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_opt/src/lib.rs
+++ b/crates/sophus_opt/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_renderer/Cargo.toml
+++ b/crates/sophus_renderer/Cargo.toml
@@ -42,3 +42,6 @@ std = [
   "sophus_sensor/std",
   "sophus_tensor/std",
 ]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_renderer/src/lib.rs
+++ b/crates/sophus_renderer/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_sensor/Cargo.toml
+++ b/crates/sophus_sensor/Cargo.toml
@@ -32,3 +32,6 @@ std = [
   "sophus_image/std",
 ]
 default = ["std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_sensor/src/lib.rs
+++ b/crates/sophus_sensor/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 #![no_std]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_sim/Cargo.toml
+++ b/crates/sophus_sim/Cargo.toml
@@ -39,3 +39,6 @@ std = [
   "sophus_sensor/std",
 ]
 default = ["std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_sim/src/lib.rs
+++ b/crates/sophus_sim/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_spline/Cargo.toml
+++ b/crates/sophus_spline/Cargo.toml
@@ -26,3 +26,6 @@ std = [
   "sophus_autodiff/std",
 ]
 default = ["std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_spline/src/lib.rs
+++ b/crates/sophus_spline/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_tensor/Cargo.toml
+++ b/crates/sophus_tensor/Cargo.toml
@@ -28,3 +28,6 @@ rustc_version.workspace = true
 simd = ["sophus_autodiff/simd"]
 std = ["sophus_autodiff/std"]
 default = ["std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_tensor/src/lib.rs
+++ b/crates/sophus_tensor/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_timeseries/Cargo.toml
+++ b/crates/sophus_timeseries/Cargo.toml
@@ -24,3 +24,6 @@ rustc_version.workspace = true
 simd = ["sophus_geo/simd"]
 std = ["sophus_geo/std"]
 default = ["std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_timeseries/src/lib.rs
+++ b/crates/sophus_timeseries/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]

--- a/crates/sophus_viewer/Cargo.toml
+++ b/crates/sophus_viewer/Cargo.toml
@@ -52,3 +52,6 @@ std = [
   "sophus_renderer/std",
   "sophus_sensor/std",
 ]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/sophus_viewer/src/lib.rs
+++ b/crates/sophus_viewer/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![allow(clippy::needless_range_loop)]
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, nightly), feature(doc_auto_cfg))]
 
 #[doc = include_str!(concat!("../",  core::env!("CARGO_PKG_README")))]
 #[cfg(doctest)]


### PR DESCRIPTION
## Summary
- enable `doc_auto_cfg` on docs.rs to annotate items with required features
- ensure each crate's docs build with all features via `package.metadata.docs.rs`

## Testing
- `cargo test --workspace --features std` *(fails: Failed to download from crates.io [CONNECT tunnel failed, response 403])*

------
https://chatgpt.com/codex/tasks/task_e_6896c349c70c8326a40b8a6bdb8c713a